### PR TITLE
Remove `include "arrow/api.h" from graph.h

### DIFF
--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -81,6 +81,10 @@ Vertices Collection
     :members:
     :undoc-members:
 
+.. doxygenclass:: GraphArchive::VertexIter
+    :members:
+    :undoc-members:
+
 .. doxygenclass:: GraphArchive::VerticesCollection
     :members:
     :undoc-members:

--- a/include/gar/graph.h
+++ b/include/gar/graph.h
@@ -82,8 +82,6 @@ class Vertex {
   std::map<std::string, std::any> properties_;
 };
 
-
-
 /**
  * @brief Edge contains information of certain edge.
  */
@@ -138,7 +136,6 @@ class Edge {
   std::map<std::string, std::any> properties_;
 };
 
-
 /**
  * @brief The iterator for traversing a type of vertices.
  *
@@ -153,7 +150,7 @@ class VertexIter {
    * @param offset The current offset of the readers.
    */
   explicit VertexIter(const VertexInfo& vertex_info, const std::string& prefix,
-                    IdType offset) noexcept {
+                      IdType offset) noexcept {
     for (const auto& pg : vertex_info.GetPropertyGroups()) {
       readers_.emplace_back(vertex_info, pg, prefix);
     }
@@ -189,8 +186,7 @@ class VertexIter {
     }
     if (column != nullptr) {
       auto array = util::GetArrowArrayByChunkIndex(column, 0);
-      GAR_ASSIGN_OR_RAISE(auto data,
-                          util::GetArrowArrayData(array));
+      GAR_ASSIGN_OR_RAISE(auto data, util::GetArrowArrayData(array));
       return util::ValueGetter<T>::Value(data, 0);
     }
     return Status::KeyError("The property is not exist.");
@@ -365,10 +361,8 @@ class EdgeIter {
   /// Get the source vertex id for the current edge.
   IdType source();
 
-
   /// Get the destination vertex id for the current edge.
   IdType destination();
-
 
   /// Get the value of a property for the current edge.
   template <typename T>

--- a/include/gar/utils/utils.h
+++ b/include/gar/utils/utils.h
@@ -99,7 +99,8 @@ std::shared_ptr<arrow::ChunkedArray> GetArrowColumnByName(
     std::shared_ptr<arrow::Table> const& table, const std::string& name);
 
 std::shared_ptr<arrow::Array> GetArrowArrayByChunkIndex(
-    std::shared_ptr<arrow::ChunkedArray> const& chunk_array, int64_t chunk_index);
+    std::shared_ptr<arrow::ChunkedArray> const& chunk_array,
+    int64_t chunk_index);
 
 Result<const void*> GetArrowArrayData(
     std::shared_ptr<arrow::Array> const& array);

--- a/include/gar/utils/utils.h
+++ b/include/gar/utils/utils.h
@@ -26,9 +26,12 @@ limitations under the License.
 
 #define REGULAR_SEPERATOR "_"
 
+// forward declarations
 namespace arrow {
+class Table;
+class ChunkedArray;
 class Array;
-}
+}  // namespace arrow
 
 namespace GAR_NAMESPACE_INTERNAL {
 
@@ -91,6 +94,12 @@ static inline std::pair<IdType, IdType> GlobalChunkIndexToIndexPair(
   }
   return index_pair;
 }
+
+std::shared_ptr<arrow::ChunkedArray> GetArrowColumnByName(
+    std::shared_ptr<arrow::Table> const& table, const std::string& name);
+
+std::shared_ptr<arrow::Array> GetArrowArrayByChunkIndex(
+    std::shared_ptr<arrow::ChunkedArray> const& chunk_array, int64_t chunk_index);
 
 Result<const void*> GetArrowArrayData(
     std::shared_ptr<arrow::Array> const& array);

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -148,8 +148,8 @@ bool EdgeIter::first_src(const EdgeIter& from, IdType id) {
 
   // unordered_by_source
   if (adj_list_type_ == AdjListType::unordered_by_source) {
-    IdType expect_chunk_index = index_converter_->IndexPairToGlobalChunkIndex(
-        id / src_chunk_size_, 0);
+    IdType expect_chunk_index =
+        index_converter_->IndexPairToGlobalChunkIndex(id / src_chunk_size_, 0);
     if (expect_chunk_index > chunk_end_)
       return false;
     if (from.global_chunk_index_ > chunk_end_ ||
@@ -197,8 +197,8 @@ bool EdgeIter::first_src(const EdgeIter& from, IdType id) {
   if (!maybe_offset_chunk.status().ok()) {
     return false;
   }
-  auto offset_array = std::dynamic_pointer_cast<arrow::Int64Array>(
-      maybe_offset_chunk.value());
+  auto offset_array =
+      std::dynamic_pointer_cast<arrow::Int64Array>(maybe_offset_chunk.value());
   auto begin_offset = static_cast<IdType>(offset_array->Value(0));
   auto end_offset = static_cast<IdType>(offset_array->Value(1));
   if (begin_offset >= end_offset) {
@@ -271,8 +271,8 @@ bool EdgeIter::first_dst(const EdgeIter& from, IdType id) {
 
   // unordered_by_dest
   if (adj_list_type_ == AdjListType::unordered_by_dest) {
-    IdType expect_chunk_index = index_converter_->IndexPairToGlobalChunkIndex(
-        id / dst_chunk_size_, 0);
+    IdType expect_chunk_index =
+        index_converter_->IndexPairToGlobalChunkIndex(id / dst_chunk_size_, 0);
     if (expect_chunk_index > chunk_end_)
       return false;
     if (from.global_chunk_index_ > chunk_end_ ||
@@ -320,8 +320,8 @@ bool EdgeIter::first_dst(const EdgeIter& from, IdType id) {
   if (!maybe_offset_chunk.status().ok()) {
     return false;
   }
-  auto offset_array = std::dynamic_pointer_cast<arrow::Int64Array>(
-      maybe_offset_chunk.value());
+  auto offset_array =
+      std::dynamic_pointer_cast<arrow::Int64Array>(maybe_offset_chunk.value());
   auto begin_offset = static_cast<IdType>(offset_array->Value(0));
   auto end_offset = static_cast<IdType>(offset_array->Value(1));
   if (begin_offset >= end_offset) {

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -97,4 +97,267 @@ Edge::Edge(
     }
   }
 }
+
+IdType EdgeIter::source() {
+  adj_list_reader_.seek(cur_offset_);
+  GAR_ASSIGN_OR_RAISE_ERROR(auto chunk, adj_list_reader_.GetChunk());
+  auto src_column = chunk->column(0);
+  return std::dynamic_pointer_cast<arrow::Int64Array>(src_column->chunk(0))
+      ->GetView(0);
+}
+
+IdType EdgeIter::destination() {
+  adj_list_reader_.seek(cur_offset_);
+  GAR_ASSIGN_OR_RAISE_ERROR(auto chunk, adj_list_reader_.GetChunk());
+  auto src_column = chunk->column(1);
+  return std::dynamic_pointer_cast<arrow::Int64Array>(src_column->chunk(0))
+      ->GetView(0);
+}
+
+bool EdgeIter::first_src(const EdgeIter& from, IdType id) {
+  if (from.is_end())
+    return false;
+
+  // ordered_by_dest or unordered_by_dest
+  if (adj_list_type_ == AdjListType::ordered_by_dest ||
+      adj_list_type_ == AdjListType::unordered_by_dest) {
+    if (from.global_chunk_index_ > chunk_end_ ||
+        (from.global_chunk_index_ == chunk_end_ &&
+         from.cur_offset_ > offset_of_chunk_end_)) {
+      return false;
+    }
+    if (from.global_chunk_index_ == global_chunk_index_) {
+      cur_offset_ = from.cur_offset_;
+    } else if (from.global_chunk_index_ < chunk_begin_ ||
+               (from.global_chunk_index_ == chunk_begin_ &&
+                from.cur_offset_ < offset_of_chunk_begin_)) {
+      this->to_begin();
+    } else {
+      global_chunk_index_ = from.global_chunk_index_;
+      cur_offset_ = from.cur_offset_;
+      vertex_chunk_index_ = from.vertex_chunk_index_;
+      this->refresh();
+    }
+    while (!this->is_end()) {
+      if (this->source() == id)
+        return true;
+      this->operator++();
+    }
+    return false;
+  }
+
+  // unordered_by_source
+  if (adj_list_type_ == AdjListType::unordered_by_source) {
+    IdType expect_chunk_index = index_converter_->IndexPairToGlobalChunkIndex(
+        id / src_chunk_size_, 0);
+    if (expect_chunk_index > chunk_end_)
+      return false;
+    if (from.global_chunk_index_ > chunk_end_ ||
+        (from.global_chunk_index_ == chunk_end_ &&
+         from.cur_offset_ > offset_of_chunk_end_)) {
+      return false;
+    }
+    bool need_refresh = false;
+    if (from.global_chunk_index_ == global_chunk_index_) {
+      cur_offset_ = from.cur_offset_;
+    } else if (from.global_chunk_index_ < chunk_begin_ ||
+               (from.global_chunk_index_ == chunk_begin_ &&
+                from.cur_offset_ < offset_of_chunk_begin_)) {
+      this->to_begin();
+    } else {
+      global_chunk_index_ = from.global_chunk_index_;
+      cur_offset_ = from.cur_offset_;
+      vertex_chunk_index_ = from.vertex_chunk_index_;
+      need_refresh = true;
+    }
+    if (global_chunk_index_ < expect_chunk_index) {
+      global_chunk_index_ = expect_chunk_index;
+      cur_offset_ = 0;
+      vertex_chunk_index_ = id / src_chunk_size_;
+      need_refresh = true;
+    }
+    if (need_refresh)
+      this->refresh();
+    while (!this->is_end()) {
+      if (this->source() == id)
+        return true;
+      if (vertex_chunk_index_ > id / src_chunk_size_)
+        return false;
+      this->operator++();
+    }
+    return false;
+  }
+
+  // ordered_by_source
+  auto st = offset_reader_->seek(id);
+  if (!st.ok()) {
+    return false;
+  }
+  auto maybe_offset_chunk = offset_reader_->GetChunk();
+  if (!maybe_offset_chunk.status().ok()) {
+    return false;
+  }
+  auto offset_array = std::dynamic_pointer_cast<arrow::Int64Array>(
+      maybe_offset_chunk.value());
+  auto begin_offset = static_cast<IdType>(offset_array->Value(0));
+  auto end_offset = static_cast<IdType>(offset_array->Value(1));
+  if (begin_offset >= end_offset) {
+    return false;
+  }
+  auto vertex_chunk_index_of_id = offset_reader_->GetChunkIndex();
+  auto begin_global_index = index_converter_->IndexPairToGlobalChunkIndex(
+      vertex_chunk_index_of_id, begin_offset / chunk_size_);
+  auto end_global_index = index_converter_->IndexPairToGlobalChunkIndex(
+      vertex_chunk_index_of_id, end_offset / chunk_size_);
+  if (begin_global_index <= from.global_chunk_index_ &&
+      from.global_chunk_index_ <= end_global_index) {
+    if (begin_offset < from.cur_offset_ && from.cur_offset_ < end_offset) {
+      global_chunk_index_ = from.global_chunk_index_;
+      cur_offset_ = from.cur_offset_;
+      vertex_chunk_index_ = from.vertex_chunk_index_;
+      refresh();
+      return true;
+    } else if (from.cur_offset_ <= begin_offset) {
+      global_chunk_index_ = begin_global_index;
+      cur_offset_ = begin_offset;
+      vertex_chunk_index_ = vertex_chunk_index_of_id;
+      refresh();
+      return true;
+    } else {
+      return false;
+    }
+  } else if (from.global_chunk_index_ < begin_global_index) {
+    global_chunk_index_ = begin_global_index;
+    cur_offset_ = begin_offset;
+    vertex_chunk_index_ = vertex_chunk_index_of_id;
+    refresh();
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool EdgeIter::first_dst(const EdgeIter& from, IdType id) {
+  if (from.is_end())
+    return false;
+
+  // ordered_by_source or unordered_by_source
+  if (adj_list_type_ == AdjListType::ordered_by_source ||
+      adj_list_type_ == AdjListType::unordered_by_source) {
+    if (from.global_chunk_index_ > chunk_end_ ||
+        (from.global_chunk_index_ == chunk_end_ &&
+         from.cur_offset_ > offset_of_chunk_end_)) {
+      return false;
+    }
+    if (from.global_chunk_index_ == global_chunk_index_) {
+      cur_offset_ = from.cur_offset_;
+    } else if (from.global_chunk_index_ < chunk_begin_ ||
+               (from.global_chunk_index_ == chunk_begin_ &&
+                from.cur_offset_ < offset_of_chunk_begin_)) {
+      this->to_begin();
+    } else {
+      global_chunk_index_ = from.global_chunk_index_;
+      cur_offset_ = from.cur_offset_;
+      vertex_chunk_index_ = from.vertex_chunk_index_;
+      this->refresh();
+    }
+    while (!this->is_end()) {
+      if (this->destination() == id)
+        return true;
+      this->operator++();
+    }
+    return false;
+  }
+
+  // unordered_by_dest
+  if (adj_list_type_ == AdjListType::unordered_by_dest) {
+    IdType expect_chunk_index = index_converter_->IndexPairToGlobalChunkIndex(
+        id / dst_chunk_size_, 0);
+    if (expect_chunk_index > chunk_end_)
+      return false;
+    if (from.global_chunk_index_ > chunk_end_ ||
+        (from.global_chunk_index_ == chunk_end_ &&
+         from.cur_offset_ > offset_of_chunk_end_)) {
+      return false;
+    }
+    bool need_refresh = false;
+    if (from.global_chunk_index_ == global_chunk_index_) {
+      cur_offset_ = from.cur_offset_;
+    } else if (from.global_chunk_index_ < chunk_begin_ ||
+               (from.global_chunk_index_ == chunk_begin_ &&
+                from.cur_offset_ < offset_of_chunk_begin_)) {
+      this->to_begin();
+    } else {
+      global_chunk_index_ = from.global_chunk_index_;
+      cur_offset_ = from.cur_offset_;
+      vertex_chunk_index_ = from.vertex_chunk_index_;
+      need_refresh = true;
+    }
+    if (global_chunk_index_ < expect_chunk_index) {
+      global_chunk_index_ = expect_chunk_index;
+      cur_offset_ = 0;
+      vertex_chunk_index_ = id / dst_chunk_size_;
+      need_refresh = true;
+    }
+    if (need_refresh)
+      this->refresh();
+    while (!this->is_end()) {
+      if (this->destination() == id)
+        return true;
+      if (vertex_chunk_index_ > id / dst_chunk_size_)
+        return false;
+      this->operator++();
+    }
+    return false;
+  }
+
+  // ordered_by_dest
+  auto st = offset_reader_->seek(id);
+  if (!st.ok()) {
+    return false;
+  }
+  auto maybe_offset_chunk = offset_reader_->GetChunk();
+  if (!maybe_offset_chunk.status().ok()) {
+    return false;
+  }
+  auto offset_array = std::dynamic_pointer_cast<arrow::Int64Array>(
+      maybe_offset_chunk.value());
+  auto begin_offset = static_cast<IdType>(offset_array->Value(0));
+  auto end_offset = static_cast<IdType>(offset_array->Value(1));
+  if (begin_offset >= end_offset) {
+    return false;
+  }
+  auto vertex_chunk_index_of_id = offset_reader_->GetChunkIndex();
+  auto begin_global_index = index_converter_->IndexPairToGlobalChunkIndex(
+      vertex_chunk_index_of_id, begin_offset / chunk_size_);
+  auto end_global_index = index_converter_->IndexPairToGlobalChunkIndex(
+      vertex_chunk_index_of_id, end_offset / chunk_size_);
+  if (begin_global_index <= from.global_chunk_index_ &&
+      from.global_chunk_index_ <= end_global_index) {
+    if (begin_offset < from.cur_offset_ && from.cur_offset_ < end_offset) {
+      global_chunk_index_ = from.global_chunk_index_;
+      cur_offset_ = from.cur_offset_;
+      vertex_chunk_index_ = from.vertex_chunk_index_;
+      refresh();
+      return true;
+    } else if (from.cur_offset_ <= begin_offset) {
+      global_chunk_index_ = begin_global_index;
+      cur_offset_ = begin_offset;
+      vertex_chunk_index_ = vertex_chunk_index_of_id;
+      refresh();
+      return true;
+    } else {
+      return false;
+    }
+  } else if (from.global_chunk_index_ < begin_global_index) {
+    global_chunk_index_ = begin_global_index;
+    cur_offset_ = begin_offset;
+    vertex_chunk_index_ = vertex_chunk_index_of_id;
+    refresh();
+    return true;
+  } else {
+    return false;
+  }
+}
+
 }  // namespace GAR_NAMESPACE_INTERNAL

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -24,6 +24,16 @@ namespace GAR_NAMESPACE_INTERNAL {
 
 namespace util {
 
+std::shared_ptr<arrow::ChunkedArray> GetArrowColumnByName(
+    std::shared_ptr<arrow::Table> const& table, const std::string& name) {
+  return table->GetColumnByName(name);
+}
+
+std::shared_ptr<arrow::Array> GetArrowArrayByChunkIndex(
+    std::shared_ptr<arrow::ChunkedArray> const& chunk_array, int64_t chunk_index) {
+  return chunk_array->chunk(chunk_index);
+}
+
 Result<const void*> GetArrowArrayData(
     std::shared_ptr<arrow::Array> const& array) {
   if (array->type()->Equals(arrow::int8())) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -30,7 +30,8 @@ std::shared_ptr<arrow::ChunkedArray> GetArrowColumnByName(
 }
 
 std::shared_ptr<arrow::Array> GetArrowArrayByChunkIndex(
-    std::shared_ptr<arrow::ChunkedArray> const& chunk_array, int64_t chunk_index) {
+    std::shared_ptr<arrow::ChunkedArray> const& chunk_array,
+    int64_t chunk_index) {
   return chunk_array->chunk(chunk_index);
 }
 


### PR DESCRIPTION
## Proposed changes

The changes remove `include "arrow/api.h" from graph.h to avoid include any arrow header in GraphAr header files.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Fixed issue #49 

