### PR TITLE
[Improve] Add auxiliary functions to get vertex chunk num or edge chunk num with infos

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,9 @@ jobs:
           popd
 
       - name: Preview using surge
-        if: ${{ github.event_name == 'pull_request_target' && github.repository == 'alibaba/GraphAr' }}
+        # if: ${{ github.event_name == 'pull_request_target' && github.repository == 'alibaba/GraphAr' }}
+        # FIXME: Error: auth() received invalid user or password
+        if: false
         run: |
           npm install -g surge
           surge ./docs/_build/html \

--- a/include/gar/utils/filesystem.h
+++ b/include/gar/utils/filesystem.h
@@ -113,7 +113,7 @@ class FileSystem {
    *
    * the file is not pure file, it can be a directory or other type of file.
    */
-  Result<size_t> GetFileNumOfDir(const std::string& dir_path,
+  Result<IdType> GetFileNumOfDir(const std::string& dir_path,
                                  bool recursive = false) const noexcept;
 
  private:

--- a/include/gar/utils/reader_utils.h
+++ b/include/gar/utils/reader_utils.h
@@ -29,6 +29,11 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
     const EdgeInfo& edge_info, const std::string& prefix,
     AdjListType adj_list_type, IdType vid) noexcept;
 
+Result<int64_t> GetVertexChunkNum(const std::string& prefix,
+                                  const VertexInfo& vertex_info) noexcept;
+
+Result<int64_t> GetEdgeChunkNum(const std::string& prefix) noexcept;
+
 }  // namespace utils
 }  // namespace GAR_NAMESPACE_INTERNAL
 #endif  // GAR_UTILS_READER_UTILS_H_

--- a/include/gar/utils/reader_utils.h
+++ b/include/gar/utils/reader_utils.h
@@ -33,7 +33,7 @@ Result<int64_t> GetVertexChunkNum(const std::string& prefix,
                                   const VertexInfo& vertex_info) noexcept;
 
 Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
-                                const EdgeInfo& edge_info
+                                const EdgeInfo& edge_info,
                                 AdjListType adj_list_type,
                                 IdType vertex_chunk_index) noexcept;
 

--- a/include/gar/utils/reader_utils.h
+++ b/include/gar/utils/reader_utils.h
@@ -32,7 +32,10 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
 Result<int64_t> GetVertexChunkNum(const std::string& prefix,
                                   const VertexInfo& vertex_info) noexcept;
 
-Result<int64_t> GetEdgeChunkNum(const std::string& prefix) noexcept;
+Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
+                                const EdgeInfo& edge_info
+                                AdjListType adj_list_type,
+                                IdType vertex_chunk_index) noexcept;
 
 }  // namespace utils
 }  // namespace GAR_NAMESPACE_INTERNAL

--- a/include/gar/utils/reader_utils.h
+++ b/include/gar/utils/reader_utils.h
@@ -29,13 +29,13 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
     const EdgeInfo& edge_info, const std::string& prefix,
     AdjListType adj_list_type, IdType vid) noexcept;
 
-Result<int64_t> GetVertexChunkNum(const std::string& prefix,
-                                  const VertexInfo& vertex_info) noexcept;
+Result<IdType> GetVertexChunkNum(const std::string& prefix,
+                                 const VertexInfo& vertex_info) noexcept;
 
-Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
-                                const EdgeInfo& edge_info,
-                                AdjListType adj_list_type,
-                                IdType vertex_chunk_index) noexcept;
+Result<IdType> GetEdgeChunkNum(const std::string& prefix,
+                               const EdgeInfo& edge_info,
+                               AdjListType adj_list_type,
+                               IdType vertex_chunk_index) noexcept;
 
 }  // namespace utils
 }  // namespace GAR_NAMESPACE_INTERNAL

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -166,7 +166,7 @@ Status FileSystem::CopyFile(const std::string& src_path,
   return Status::OK();
 }
 
-Result<size_t> FileSystem::GetFileNumOfDir(const std::string& dir_path,
+Result<IdType> FileSystem::GetFileNumOfDir(const std::string& dir_path,
                                            bool recursive) const noexcept {
   arrow::fs::FileSelector file_selector;
   file_selector.base_dir = dir_path;
@@ -175,7 +175,7 @@ Result<size_t> FileSystem::GetFileNumOfDir(const std::string& dir_path,
   arrow::fs::FileInfoVector file_infos;
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(file_infos,
                                        arrow_fs_->GetFileInfo(file_selector));
-  return file_infos.size();
+  return static_cast<IdType>(file_infos.size());
 }
 
 Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -69,15 +69,14 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
 
 Result<IdType> GetVertexChunkNum(const std::string& prefix,
                                  const VertexInfo& vertex_info) noexcept {
-  const auto& property_groups = vertex_info.GetPropertyGroups();
-  if (property_groups.empty()) {
-    return 0;
-  }
   std::string out_prefix;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
-  std::string chunk_dir =
-      out_prefix + vertex_info.GetPathPrefix(property_groups[0]).value();
-  return fs->GetFileNumOfDir(chunk_dir);
+  GAR_ASSIGN_OR_RAISE(auto vertex_num_file_suffix,
+      vertex_info.GetFiGetVerticesNumFilePath());
+  std::string vertex_num_file_path = out_prefix + vertex_num_file_suffix;
+  IdType vertex_num = fs->ReadFileToValue<IdType>(vertex_num_file_path);
+  return vertex_num + vertex_info.GetChunkSize() - 1 /
+      vertex_info.GetChunkSize();
 }
 
 Result<IdType> GetEdgeChunkNum(const std::string& prefix,

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -72,9 +72,10 @@ Result<IdType> GetVertexChunkNum(const std::string& prefix,
   std::string out_prefix;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
   GAR_ASSIGN_OR_RAISE(auto vertex_num_file_suffix,
-                      vertex_info.GetFiGetVerticesNumFilePath());
+                      vertex_info.GetVerticesNumFilePath());
   std::string vertex_num_file_path = out_prefix + vertex_num_file_suffix;
-  IdType vertex_num = fs->ReadFileToValue<IdType>(vertex_num_file_path);
+  GAR_ASSIGN_OR_RAISE(auto vertex_num,
+                      fs->ReadFileToValue<IdType>(vertex_num_file_path));
   return vertex_num + vertex_info.GetChunkSize() -
          1 / vertex_info.GetChunkSize();
 }

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -76,7 +76,7 @@ Result<int64_t> GetVertexChunkNum(const std::string& prefix,
   std::string out_prefix;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
   std::string chunk_dir =
-      out_prefix + vertex_info.GetPathPrefix(property_groups[0]);
+      out_prefix + vertex_info.GetPathPrefix(property_groups[0]).value();
   return fs->GetFileNumOfDir(chunk_dir);
 }
 
@@ -87,8 +87,9 @@ Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
   std::string out_prefix;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
   GAR_ASSIGN_OR_RAISE(auto adj_prefix, edge_info.GetAdjListPathPrefix(adj_list_type));
-  std::string chunk_dir = out_prefix + adj_prefix + "part" + std::string(vertex_chunk_index);
+  std::string chunk_dir = out_prefix + adj_prefix + "part" + std::to_string(vertex_chunk_index);
   return fs->GetFileNumOfDir(chunk_dir);
+}
 
 }  // namespace utils
 

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -72,11 +72,11 @@ Result<IdType> GetVertexChunkNum(const std::string& prefix,
   std::string out_prefix;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
   GAR_ASSIGN_OR_RAISE(auto vertex_num_file_suffix,
-      vertex_info.GetFiGetVerticesNumFilePath());
+                      vertex_info.GetFiGetVerticesNumFilePath());
   std::string vertex_num_file_path = out_prefix + vertex_num_file_suffix;
   IdType vertex_num = fs->ReadFileToValue<IdType>(vertex_num_file_path);
-  return vertex_num + vertex_info.GetChunkSize() - 1 /
-      vertex_info.GetChunkSize();
+  return vertex_num + vertex_info.GetChunkSize() -
+         1 / vertex_info.GetChunkSize();
 }
 
 Result<IdType> GetEdgeChunkNum(const std::string& prefix,

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -67,8 +67,8 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
                         static_cast<IdType>(array->Value(1)));
 }
 
-Result<int64_t> GetVertexChunkNum(const std::string& prefix,
-                                  const VertexInfo& vertex_info) noexcept {
+Result<IdType> GetVertexChunkNum(const std::string& prefix,
+                                 const VertexInfo& vertex_info) noexcept {
   const auto& property_groups = vertex_info.GetPropertyGroups();
   if (property_groups.empty()) {
     return 0;
@@ -80,14 +80,16 @@ Result<int64_t> GetVertexChunkNum(const std::string& prefix,
   return fs->GetFileNumOfDir(chunk_dir);
 }
 
-Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
-                                const EdgeInfo& edge_info,
-                                AdjListType adj_list_type,
-                                IdType vertex_chunk_index) noexcept {
+Result<IdType> GetEdgeChunkNum(const std::string& prefix,
+                               const EdgeInfo& edge_info,
+                               AdjListType adj_list_type,
+                               IdType vertex_chunk_index) noexcept {
   std::string out_prefix;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
-  GAR_ASSIGN_OR_RAISE(auto adj_prefix, edge_info.GetAdjListPathPrefix(adj_list_type));
-  std::string chunk_dir = out_prefix + adj_prefix + "part" + std::to_string(vertex_chunk_index);
+  GAR_ASSIGN_OR_RAISE(auto adj_prefix,
+                      edge_info.GetAdjListPathPrefix(adj_list_type));
+  std::string chunk_dir =
+      out_prefix + adj_prefix + "part" + std::to_string(vertex_chunk_index);
   return fs->GetFileNumOfDir(chunk_dir);
 }
 

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -81,7 +81,7 @@ Result<int64_t> GetVertexChunkNum(const std::string& prefix,
 }
 
 Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
-                                const EdgeInfo& edge_info
+                                const EdgeInfo& edge_info,
                                 AdjListType adj_list_type,
                                 IdType vertex_chunk_index) noexcept {
   std::string out_prefix;

--- a/src/reader_utils.cc
+++ b/src/reader_utils.cc
@@ -67,6 +67,29 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
                         static_cast<IdType>(array->Value(1)));
 }
 
+Result<int64_t> GetVertexChunkNum(const std::string& prefix,
+                                  const VertexInfo& vertex_info) noexcept {
+  const auto& property_groups = vertex_info.GetPropertyGroups();
+  if (property_groups.empty()) {
+    return 0;
+  }
+  std::string out_prefix;
+  GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
+  std::string chunk_dir =
+      out_prefix + vertex_info.GetPathPrefix(property_groups[0]);
+  return fs->GetFileNumOfDir(chunk_dir);
+}
+
+Result<int64_t> GetEdgeChunkNum(const std::string& prefix,
+                                const EdgeInfo& edge_info
+                                AdjListType adj_list_type,
+                                IdType vertex_chunk_index) noexcept {
+  std::string out_prefix;
+  GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(prefix, &out_prefix));
+  GAR_ASSIGN_OR_RAISE(auto adj_prefix, edge_info.GetAdjListPathPrefix(adj_list_type));
+  std::string chunk_dir = out_prefix + adj_prefix + "part" + std::string(vertex_chunk_index);
+  return fs->GetFileNumOfDir(chunk_dir);
+
 }  // namespace utils
 
 }  // namespace GAR_NAMESPACE_INTERNAL


### PR DESCRIPTION
## Proposed changes
These changes add some auxiliary functions to get vertex chunk num or edge chunk num with vertex info, edge info and directory path to check.
if the directory not exist, it would raise an ArrowError

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Fixed issues #90