### PR TITLE
Add prefix to arrow definitions to avoid conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,8 +158,6 @@ endif()
 include(apache-arrow)
 build_arrow()
 
-include_directories(BEFORE SYSTEM ${ARROW_INCLUDE_DIR})
-
 macro(get_target_location var target)
   if(TARGET ${target})
     foreach(prop LOCATION LOCATION_NOCONFIG LOCATION_DEBUG LOCATION_RELEASE)
@@ -183,24 +181,26 @@ macro(build_gar)
                                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
                                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/yaml-cpp/include>
     )
+    target_include_directories(gar PRIVATE SYSTEM BEFORE ${GAR_ARROW_INCLUDE_DIR})
     target_link_libraries(gar PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+
     # make sure `libyaml-cpp.a` built first
     add_dependencies(gar yaml-cpp)
     get_target_location(YAML_CPP_LIBRARY_LOCATION yaml-cpp)
     if(APPLE)
         target_link_libraries(gar PRIVATE -Wl,-force_load gar_arrow_static
             "${YAML_CPP_LIBRARY_LOCATION}"
-            "${PARQUET_STATIC_LIB}"
-            "${ARROW_BUNDLED_DEPS_STATIC_LIB}")
+            "${GAR_PARQUET_STATIC_LIB}"
+            "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}")
     else()
         target_link_libraries(gar PRIVATE -Wl,--exclude-libs,ALL -Wl,--whole-archive gar_arrow_static
             "${YAML_CPP_LIBRARY_LOCATION}"
-            "${PARQUET_STATIC_LIB}"
-            "${ARROW_BUNDLED_DEPS_STATIC_LIB}" -Wl,--no-whole-archive)
+            "${GAR_PARQUET_STATIC_LIB}"
+            "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}" -Wl,--no-whole-archive)
     endif()
 
     # if OpenSSL library exists, link the OpenSSL library.
-    # OpenSSL has to be linked after ARROW_BUNDLED_DEPS_STATIC_LIB
+    # OpenSSL has to be linked after GAR_ARROW_BUNDLED_DEPS_STATIC_LIB
     if(OPENSSL_FOUND)
         target_link_libraries(gar PRIVATE OpenSSL::SSL)
     endif()
@@ -225,16 +225,16 @@ if (BUILD_EXAMPLES)
         target_link_libraries(${E_NAME} PRIVATE gar ${Boost_LIBRARIES} Threads::Threads ${CMAKE_DL_LIBS})
         if(APPLE)
             target_link_libraries(${E_NAME} PRIVATE -Wl,-force_load gar_arrow_static
-                "${PARQUET_STATIC_LIB}"
-                "${ARROW_BUNDLED_DEPS_STATIC_LIB}")
+                "${GAR_PARQUET_STATIC_LIB}"
+                "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}")
         else()
             target_link_libraries(${E_NAME} PRIVATE -Wl,--exclude-libs,ALL -Wl,--whole-archive gar_arrow_static
-                "${PARQUET_STATIC_LIB}"
-                "${ARROW_BUNDLED_DEPS_STATIC_LIB}" -Wl,--no-whole-archive)
+                "${GAR_PARQUET_STATIC_LIB}"
+                "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}" -Wl,--no-whole-archive)
         endif()
 
         # if OpenSSL library exists, link the OpenSSL library.
-        # OpenSSL has to be linked after ARROW_BUNDLED_DEPS_STATIC_LIB
+        # OpenSSL has to be linked after GAR_ARROW_BUNDLED_DEPS_STATIC_LIB
         if(OPENSSL_FOUND)
             target_link_libraries(${E_NAME} PRIVATE OpenSSL::SSL)
         endif()
@@ -290,12 +290,12 @@ if (BUILD_TESTS)
         target_link_libraries(${target} PRIVATE Catch2::Catch2 gar Threads::Threads ${CMAKE_DL_LIBS})
         if(APPLE)
             target_link_libraries(${target} PRIVATE -Wl,-force_load gar_arrow_static
-                "${PARQUET_STATIC_LIB}"
-                "${ARROW_BUNDLED_DEPS_STATIC_LIB}")
+                "${GAR_PARQUET_STATIC_LIB}"
+                "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}")
         else()
             target_link_libraries(${target} PRIVATE -Wl,--exclude-libs,ALL -Wl,--whole-archive gar_arrow_static
-                "${PARQUET_STATIC_LIB}"
-                "${ARROW_BUNDLED_DEPS_STATIC_LIB}" -Wl,--no-whole-archive)
+                "${GAR_PARQUET_STATIC_LIB}"
+                "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}" -Wl,--no-whole-archive)
         endif()
         target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR}/include $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/Catch2/single_include>)
         include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
@@ -304,7 +304,7 @@ if (BUILD_TESTS)
         catch_discover_tests(${target})
 
         # if OpenSSL library exists, link the OpenSSL library.
-        # OpenSSL has to be linked after ARROW_BUNDLED_DEPS_STATIC_LIB
+        # OpenSSL has to be linked after GAR_ARROW_BUNDLED_DEPS_STATIC_LIB
         if(OPENSSL_FOUND)
             target_link_libraries(${target} PRIVATE OpenSSL::SSL)
         endif()

--- a/cmake/apache-arrow.cmake
+++ b/cmake/apache-arrow.cmake
@@ -35,58 +35,73 @@ function(build_arrow)
 
     find_package(Threads)
     # If Arrow needs to be built, the default location will be within the build tree.
-    set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix")
+    set(GAR_ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix")
 
-    set(ARROW_STATIC_LIBRARY_DIR "${ARROW_PREFIX}/lib")
+    set(GAR_ARROW_STATIC_LIBRARY_DIR "${GAR_ARROW_PREFIX}/lib")
 
-    set(ARROW_STATIC_LIB_FILENAME
+    set(GAR_ARROW_STATIC_LIB_FILENAME
             "${CMAKE_STATIC_LIBRARY_PREFIX}arrow${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    set(ARROW_STATIC_LIB "${ARROW_STATIC_LIBRARY_DIR}/${ARROW_STATIC_LIB_FILENAME}")
-    set(PARQUET_STATIC_LIB_FILENAME
+    set(GAR_ARROW_STATIC_LIB "${GAR_ARROW_STATIC_LIBRARY_DIR}/${GAR_ARROW_STATIC_LIB_FILENAME}")
+    set(GAR_PARQUET_STATIC_LIB_FILENAME
 	    "${CMAKE_STATIC_LIBRARY_PREFIX}parquet${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    set(PARQUET_STATIC_LIB "${ARROW_STATIC_LIBRARY_DIR}/${PARQUET_STATIC_LIB_FILENAME}" CACHE INTERNAL "parquet lib")
-    set(ARROW_BUNDLED_DEPS_STATIC_LIB_FILENAME
+    set(GAR_PARQUET_STATIC_LIB "${GAR_ARROW_STATIC_LIBRARY_DIR}/${GAR_PARQUET_STATIC_LIB_FILENAME}" CACHE INTERNAL "parquet lib")
+    set(GAR_ARROW_BUNDLED_DEPS_STATIC_LIB_FILENAME
         "${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    set(ARROW_BUNDLED_DEPS_STATIC_LIB
-        "${ARROW_STATIC_LIBRARY_DIR}/${ARROW_BUNDLED_DEPS_STATIC_LIB_FILENAME}" CACHE INTERNAL "bundled deps lib")
+    set(GAR_ARROW_BUNDLED_DEPS_STATIC_LIB
+        "${GAR_ARROW_STATIC_LIBRARY_DIR}/${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB_FILENAME}" CACHE INTERNAL "bundled deps lib")
 
-    set(ARROW_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-build")
-    set(ARROW_CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}"
-            "-DARROW_BUILD_STATIC=ON" "-DARROW_BUILD_SHARED=OFF"
-            "-DARROW_DEPENDENCY_SOURCE=BUNDLED" "-DARROW_DEPENDENCY_USE_SHARED=OFF"
-            "-DCMAKE_INSTALL_LIBDIR=lib" "-Dxsimd_SOURCE=BUNDLED"
-            "-DARROW_PARQUET=ON" "-DARROW_WITH_RE2=OFF"
-            "-DARROW_WITH_UTF8PROC=OFF" "-DARROW_WITH_RE2=OFF"
-            "-DARROW_FILESYSTEM=ON" "-DARROW_CSV=ON" "-DARROW_PYTHON=OFF"
-            "-DARROW_BUILD_BENCHMAKRS=OFF" "-DARROW_BUILD_TESTS=OFF"
-            "-DARROW_BUILD_INTEGRATION=OFF" "-DBoost_SOURCE=BUNDLED"
-            "-DARROW_ORC=ON" "-DARROW_COMPUTE=ON"
-            "-DARROW_DATASET=ON" "-DARROW_WITH_SNAPPY=OFF" "-DARROW_WITH_LZ4=OFF"
-            "-DARROW_WITH_ZSTD=ON" "-DARROW_WITH_ZLIB=OFF" "-DARROW_WITH_BROTLI=OFF" "-DARROW_WITH_BZ2=OFF")
+    set(GAR_ARROW_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-build")
+    set(GAR_ARROW_CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${GAR_ARROW_PREFIX}"
+                             "-DARROW_BUILD_STATIC=ON"
+                             "-DARROW_BUILD_SHARED=OFF"
+                             "-DARROW_DEPENDENCY_SOURCE=BUNDLED"
+                             "-DARROW_DEPENDENCY_USE_SHARED=OFF"
+                             "-DCMAKE_INSTALL_LIBDIR=lib"
+                             "-Dxsimd_SOURCE=BUNDLED"
+                             "-DARROW_PARQUET=ON"
+                             "-DARROW_WITH_RE2=OFF"
+                             "-DARROW_WITH_UTF8PROC=OFF"
+                             "-DARROW_WITH_RE2=OFF"
+                             "-DARROW_FILESYSTEM=ON"
+                             "-DARROW_CSV=ON"
+                             "-DARROW_PYTHON=OFF"
+                             "-DARROW_BUILD_BENCHMAKRS=OFF"
+                             "-DARROW_BUILD_TESTS=OFF"
+                             "-DARROW_BUILD_INTEGRATION=OFF"
+                             "-DBoost_SOURCE=BUNDLED"
+                             "-DARROW_ORC=ON"
+                             "-DARROW_COMPUTE=ON"
+                             "-DARROW_DATASET=ON"
+                             "-DARROW_WITH_SNAPPY=OFF"
+                             "-DARROW_WITH_LZ4=OFF"
+                             "-DARROW_WITH_ZSTD=ON"
+                             "-DARROW_WITH_ZLIB=OFF"
+                             "-DARROW_WITH_BROTLI=OFF"
+                             "-DARROW_WITH_BZ2=OFF")
 
-    set(ARROW_INCLUDE_DIR "${ARROW_PREFIX}/include" CACHE INTERNAL "arrow include directory")
-    set(ARROW_BUILD_BYPRODUCTS "${ARROW_STATIC_LIB}" "${PARQUET_STATIC_LIB}")
+    set(GAR_ARROW_INCLUDE_DIR "${GAR_ARROW_PREFIX}/include" CACHE INTERNAL "arrow include directory")
+    set(GAR_ARROW_BUILD_BYPRODUCTS "${GAR_ARROW_STATIC_LIB}" "${GAR_PARQUET_STATIC_LIB}")
 
     include(ExternalProject)
     externalproject_add(arrow_ep
             URL https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-9.0.0/apache-arrow-9.0.0.tar.gz
             SOURCE_SUBDIR cpp
-            BINARY_DIR "${ARROW_BINARY_DIR}"
-            CMAKE_ARGS "${ARROW_CMAKE_ARGS}"
-            BUILD_BYPRODUCTS "${ARROW_BUILD_BYPRODUCTS}")
+            BINARY_DIR "${GAR_ARROW_BINARY_DIR}"
+            CMAKE_ARGS "${GAR_ARROW_CMAKE_ARGS}"
+            BUILD_BYPRODUCTS "${GAR_ARROW_BUILD_BYPRODUCTS}")
 
-    set(ARROW_LIBRARY_TARGET gar_arrow_static)
-    set(PARQUET_LIBRARY_TARGET gar_parquet_static)
+    set(GAR_ARROW_LIBRARY_TARGET gar_arrow_static)
+    set(GAR_PARQUET_LIBRARY_TARGET gar_parquet_static)
 
-    file(MAKE_DIRECTORY "${ARROW_INCLUDE_DIR}")
-    add_library(${ARROW_LIBRARY_TARGET} STATIC IMPORTED)
-    add_library(${PARQUET_LIBRARY_TARGET} STATIC IMPORTED)
-    set_target_properties(${ARROW_LIBRARY_TARGET}
-            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${ARROW_INCLUDE_DIR}
-            IMPORTED_LOCATION ${ARROW_STATIC_LIB})
-    set_target_properties(${PARQUET_LIBRARY_TARGET}
-            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${ARROW_INCLUDE_DIR}
-            IMPORTED_LOCATION ${PARQUET_STATIC_LIB})
+    file(MAKE_DIRECTORY "${GAR_ARROW_INCLUDE_DIR}")
+    add_library(${GAR_ARROW_LIBRARY_TARGET} STATIC IMPORTED)
+    add_library(${GAR_PARQUET_LIBRARY_TARGET} STATIC IMPORTED)
+    set_target_properties(${GAR_ARROW_LIBRARY_TARGET}
+            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${GAR_ARROW_INCLUDE_DIR}
+            IMPORTED_LOCATION ${GAR_ARROW_STATIC_LIB})
+    set_target_properties(${GAR_PARQUET_LIBRARY_TARGET}
+            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${GAR_ARROW_INCLUDE_DIR}
+            IMPORTED_LOCATION ${GAR_PARQUET_STATIC_LIB})
 
-    add_dependencies(${ARROW_LIBRARY_TARGET} arrow_ep)
+    add_dependencies(${GAR_ARROW_LIBRARY_TARGET} arrow_ep)
 endfunction()


### PR DESCRIPTION
## Proposed changes

This pull request addresses two bugs:

- `include_directories(BEFORE SYSTEM ${ARROW_INCLUDE_DIR})` will bring `arrow_ep/include/...` to `gar`'s cmake dependency
- Without a private prefix for arrow definitions, there would be conflicts when the external projects both requires arrow and gar (using `add_subdirectory`).

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)