### PR TITLE
[Examples][Spark] Add examples of integrating with the Neo4j spark connector as an application of GraphAr

### DIFF
--- a/docs/applications/spark.rst
+++ b/docs/applications/spark.rst
@@ -1,0 +1,129 @@
+Co-Work with Apache Spark
+============================
+
+`Apache Spark <https://spark.apache.org/>`_ is a multi-language engine for executing data engineering, data science, and machine learning on single-node machines or clusters. The GraphAr Spark library is developed to make integrating graphs in GraphAr with Spark easy. Utilizing this library, one can generate, load and transform GAR files efficiently. One can also use it to integrate GraphAr to other systems that work with Spark.
+
+Some examples are provided as the showcases for co-working with Apache Spark.
+
+
+Examples
+------------------------
+
+Transform GAR files
+`````````````````````
+`TransformExample.scala`_ is an example for graph data conversion between different file types or different adjList types. For such cases, the original data will be first loaded as the Spark DataFrame using the GraphAr Spark Reader; and then, this DataFrame is written into generated GAR files through a GraphAr Spark Writer, following the meta data defined in a new information file.
+
+
+Compute with GraphX
+`````````````````````
+Another important scenario of using GraphAr is to take it as the data source for conducting graph computing or analytics. `ComputeExample.scala`_  includes an example for constructing the GraphX graph from GAR files and executing a connected-components computation. Also, executing queries with Spark SQL or running other graph analytic algorithms could be implemented in a similar way.
+
+
+Importing/Exporting Graphs of Neo4j
+``````````````````````````````````````````
+`Neo4j <https://neo4j.com/product/neo4j-graph-database/>`_ graph database provides a `spark connector <https://neo4j.com/docs/spark/current/overview/>`_ to integrate with Spark. Neo4j Spark Connector together with GraphAr Spark library enable us to migrate the graph data between Neo4j and GraphAr. This also a critical application case of GraphAr in which it acts as a persistent storage of the graph data in database.
+
+When exporting the graph data from Neo4j to GraphAr, please refer to the following code:
+
+.. code:: scala
+
+  // connect to the Neo4j instance
+  val spark = SparkSession.builder()
+    .config("neo4j.url", "bolt://localhost:7687")
+    .config("neo4j.authentication.type", "basic")
+    .config("neo4j.authentication.basic.username", sys.env.get("Neo4j_USR").get)
+    .config("neo4j.authentication.basic.password", sys.env.get("Neo4j_PWD").get)
+    .config("spark.master", "local")
+    .getOrCreate()
+  
+  // read vertices with label "Person" from Neo4j as a DataFrame
+  val person_df = spark.read.format("org.neo4j.spark.DataSource")
+    .option("labels", "Person")
+    .load()
+
+  // construct the GraphAr Spark writer
+  val person_df_with_index = IndexGenerator.generateVertexIndexColumn(person_df)
+  val vertex_info = ...     // the user-provided meta information
+  val prefix : String = ... // the prefix of the file path
+  val writer = new VertexWriter(prefix, vertex_info, person_df_with_index)
+
+  // use the DataFrame to generate GAR files
+  writer.writeVertexProperties() 
+
+See `Neo4j2GraphAr.scala`_ for the complete example.
+
+The information file for the this group of vertices looks like: 
+
+.. code:: Yaml
+
+  label: Person
+  chunk_size: 100
+  prefix: vertex/person/
+  property_groups:
+    - properties:
+        - name: <id>
+          data_type: int64
+          is_primary: false
+        - name: <labels>
+          data_type: array
+          is_primary: false
+      file_type: parquet
+    - properties:
+        - name: name
+          data_type: string
+          is_primary: true
+        - name: born
+          data_type: int64
+          is_primary: false
+      file_type: orc
+  version: gar/v1
+
+.. note::
+
+  Please note that when reading data from Neo4j with this method, the DataFrame contains all the fields contained in the nodes ((vertex properties)), plus two additional columns:
+
+  - <id> the internal Neo4j ID
+  - <labels> a list of labels for that node
+
+And when importing data from GraphAr to create/update instances in Neo4j, please refer to the following code:
+
+.. code:: scala
+  
+  // construct the GraphAr Spark reader
+  val spark_session = ...   // the spark session
+  val prefix : String = ... // the prefix of the file path
+  val reader = new VertexReader(prefix, vertex_info, spark_session)
+
+  // reading chunks for all property groups
+  val vertex_df = reader.readAllVertexPropertyGroups(false)
+
+  // group vertices with the same Neo4j labels together
+  val labels_array = vertex_df.select("<labels>").distinct.collect.flatMap(_.toSeq)
+  val vertex_df_array = labels_array.map(labels => vertex_df.where(vertex_df("<labels>") === labels))
+
+  // each time, write a group of vertices to Neo4j
+  vertex_df_array.foreach(df => {
+    val labels = df.first().getAs[Seq[String]]("<labels>")
+    var str = ""
+    labels.foreach(label => {str += ":" + label})
+    df.drop("<id>").drop("<labels>")
+      .write.format("org.neo4j.spark.DataSource")
+      .mode(SaveMode.Append)
+      .option("labels", str)
+      .save()
+  })
+
+See `GraphAr2Neo4j.scala`_ for the complete example.
+
+.. note::
+
+  The Neo4j Spark Connector provides different save modes and writing options, such as CREATE or MERGE. Please refer to its `documentation <https://neo4j.com/docs/spark/current/writing/>`_ for more information.
+
+
+.. _TransformExample.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TransformExample.scala
+
+.. _ComputeExample.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/ComputeExample.scala
+
+.. _Neo4j2GraphAr.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+
+.. _GraphAr2Neo4j.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala

--- a/docs/applications/spark.rst
+++ b/docs/applications/spark.rst
@@ -1,9 +1,9 @@
 Co-Work with Apache Spark
 ============================
 
-`Apache Spark <https://spark.apache.org/>`_ is a multi-language engine for executing data engineering, data science, and machine learning on single-node machines or clusters. The GraphAr Spark library is developed to make integrating graphs in GraphAr with Spark easy. Utilizing this library, one can generate, load and transform GAR files efficiently. One can also use it to integrate GraphAr to other systems that work with Spark.
+`Apache Spark <https://spark.apache.org/>`_ is a multi-language engine for executing data engineering, data science, and machine learning on single-node machines or clusters. The GraphAr Spark library is developed to make the integration of GraphAr with Spark easy. This library allows users to efficiently generate, load, and transform GAR files, and to integrate GraphAr with other Spark-compatible systems. 
 
-Some examples are provided as the showcases for co-working with Apache Spark.
+Examples of this co-working integration have been provided as showcases.
 
 
 Examples
@@ -11,19 +11,19 @@ Examples
 
 Transform GAR files
 `````````````````````
-`TransformExample.scala`_ is an example for graph data conversion between different file types or different adjList types. For such cases, the original data will be first loaded as the Spark DataFrame using the GraphAr Spark Reader; and then, this DataFrame is written into generated GAR files through a GraphAr Spark Writer, following the meta data defined in a new information file.
+`TransformExample.scala`_ is an example for graph data conversion between different file types or different adjList types. To do this, the original data is first loaded into a Spark DataFrame using the GraphAr Spark Reader. Then, the DataFrame is written into generated GAR files through a GraphAr Spark Writer, following the meta data defined in a new information file.
 
 
 Compute with GraphX
 `````````````````````
-Another important scenario of using GraphAr is to take it as the data source for conducting graph computing or analytics. `ComputeExample.scala`_  includes an example for constructing the GraphX graph from GAR files and executing a connected-components computation. Also, executing queries with Spark SQL or running other graph analytic algorithms could be implemented in a similar way.
+Another important use case of GraphAr is to use it as a data source for graph computing or analytics; `ComputeExample.scala`_ provides an example of constructing a GraphX graph from reading GAR files and executing a connected-components computation. Also, executing queries with Spark SQL and running other graph analytic algorithms can be implemented in a similar fashion.
 
 
-Importing/Exporting Graphs of Neo4j
-``````````````````````````````````````````
-`Neo4j <https://neo4j.com/product/neo4j-graph-database/>`_ graph database provides a `spark connector <https://neo4j.com/docs/spark/current/overview/>`_ to integrate with Spark. Neo4j Spark Connector together with GraphAr Spark library enable us to migrate the graph data between Neo4j and GraphAr. This also a critical application case of GraphAr in which it acts as a persistent storage of the graph data in database.
+Import/Export graphs of Neo4j
+```````````````````````````````
+`Neo4j <https://neo4j.com/product/neo4j-graph-database/>`_ graph database provides a `spark connector <https://neo4j.com/docs/spark/current/overview/>`_ for integration with Spark. The Neo4j Spark Connector, combined with the GraphAr Spark library, enables us to migrate graph data between Neo4j and GraphAr. This is also a key application of GraphAr in which it acts as a persistent storage of graph data in the database.
 
-When exporting the graph data from Neo4j to GraphAr, please refer to the following code:
+When exporting graph data from Neo4j and writing to GraphAr, please refer to the following code, with `Neo4j2GraphAr.scala`_ providing a complete example.
 
 .. code:: scala
 
@@ -50,9 +50,7 @@ When exporting the graph data from Neo4j to GraphAr, please refer to the followi
   // use the DataFrame to generate GAR files
   writer.writeVertexProperties() 
 
-See `Neo4j2GraphAr.scala`_ for the complete example.
-
-The information file for the this group of vertices looks like: 
+The information file for the this group of vertices may look like: 
 
 .. code:: Yaml
 
@@ -80,12 +78,12 @@ The information file for the this group of vertices looks like:
 
 .. note::
 
-  Please note that when reading data from Neo4j with this method, the DataFrame contains all the fields contained in the nodes ((vertex properties)), plus two additional columns:
+  Please note that when reading data from Neo4j with this method, the DataFrame contains all the fields contained in the nodes (vertex properties), plus two additional columns:
 
   - <id> the internal Neo4j ID
   - <labels> a list of labels for that node
 
-And when importing data from GraphAr to create/update instances in Neo4j, please refer to the following code:
+Additionally, when importing data from GraphAr to create/update instances in Neo4j, please refer to the following code:
 
 .. code:: scala
   
@@ -101,15 +99,16 @@ And when importing data from GraphAr to create/update instances in Neo4j, please
   val labels_array = vertex_df.select("<labels>").distinct.collect.flatMap(_.toSeq)
   val vertex_df_array = labels_array.map(labels => vertex_df.where(vertex_df("<labels>") === labels))
 
-  // each time, write a group of vertices to Neo4j
+  // write a group of vertices (with the same Neo4j labels) to Neo4j each time
   vertex_df_array.foreach(df => {
     val labels = df.first().getAs[Seq[String]]("<labels>")
     var str = ""
     labels.foreach(label => {str += ":" + label})
     df.drop("<id>").drop("<labels>")
       .write.format("org.neo4j.spark.DataSource")
-      .mode(SaveMode.Append)
+      .mode(SaveMode.Overwrite)
       .option("labels", str)
+      .option("node.keys", "name")
       .save()
   })
 
@@ -117,7 +116,7 @@ See `GraphAr2Neo4j.scala`_ for the complete example.
 
 .. note::
 
-  The Neo4j Spark Connector provides different save modes and writing options, such as CREATE or MERGE. Please refer to its `documentation <https://neo4j.com/docs/spark/current/writing/>`_ for more information.
+  The Neo4j Spark Connector offers different save modes and writing options, such as Append(CREATE) or Overwrite(MERGE). Please refer to its `documentation <https://neo4j.com/docs/spark/current/writing/>`_ for more information.
 
 
 .. _TransformExample.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TransformExample.scala

--- a/docs/applications/spark.rst
+++ b/docs/applications/spark.rst
@@ -23,6 +23,7 @@ Import/Export graphs of Neo4j
 ```````````````````````````````
 `Neo4j <https://neo4j.com/product/neo4j-graph-database/>`_ graph database provides a `spark connector <https://neo4j.com/docs/spark/current/overview/>`_ for integration with Spark. The Neo4j Spark Connector, combined with the GraphAr Spark library, enables us to migrate graph data between Neo4j and GraphAr. This is also a key application of GraphAr in which it acts as a persistent storage of graph data in the database.
 
+We provide two example programs that demonstrate how GraphAr can be used in conjunction with Neo4j. It utilizes one of the built-in Neo4j datasets, the `Movie Graph <https://neo4j.com/developer/example-data/#built-in-examples>`_, which is a mini graph application containing actors and directors that are related through the movies they have collaborated on. The data schemas for "Person" vertices, "Movie" vertices, and "Person PRODUCED Movie" edges can be represented in GraphAr information files in the `test data <https://github.com/GraphScope/gar-test/tree/main/neo4j>`_.
 When exporting graph data from Neo4j and writing to GraphAr, please refer to the following code, with `Neo4j2GraphAr.scala`_ providing a complete example.
 
 .. code:: scala

--- a/docs/applications/spark.rst
+++ b/docs/applications/spark.rst
@@ -115,9 +115,10 @@ Additionally, when importing data from GraphAr to create/update instances in Neo
 
 See `GraphAr2Neo4j.scala`_ for the complete example.
 
-.. note::
+.. tip::
 
-  The Neo4j Spark Connector offers different save modes and writing options, such as Append(CREATE) or Overwrite(MERGE). Please refer to its `documentation <https://neo4j.com/docs/spark/current/writing/>`_ for more information.
+  - The Neo4j Spark Connector offers different save modes and writing options, such as Append(CREATE) or Overwrite(MERGE). Please refer to its `documentation <https://neo4j.com/docs/spark/current/writing/>`_ for more information and take the most appropriate method while using.
+  - The Neo4j Spark Connector supports to use `Spark structured streaming API <https://neo4j.com/docs/spark/current/streaming/>`_, which works differently from Spark batching. One can utilize this API to read/write a stream from/to Neo4j, avoiding to maintain all data in the memory.
 
 
 .. _TestGraphTransformer.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala

--- a/docs/applications/spark.rst
+++ b/docs/applications/spark.rst
@@ -11,7 +11,7 @@ Examples
 
 Transform GAR files
 `````````````````````
-`TransformExample.scala`_ is an example for graph data conversion between different file types or different adjList types. To do this, the original data is first loaded into a Spark DataFrame using the GraphAr Spark Reader. Then, the DataFrame is written into generated GAR files through a GraphAr Spark Writer, following the meta data defined in a new information file.
+We provide an example in `TestGraphTransformer.scala`_, which demonstrates how to conduct data transformation at the graph level. `TransformExample.scala`_ is another example for graph data conversion between different file types or different adjList types, which is implemented at the vertex/edge table level. To do this, the original data is first loaded into a Spark DataFrame using the GraphAr Spark Reader. Then, the DataFrame is written into generated GAR files through a GraphAr Spark Writer, following the meta data defined in a new information file.
 
 
 Compute with GraphX
@@ -118,6 +118,8 @@ See `GraphAr2Neo4j.scala`_ for the complete example.
 
   The Neo4j Spark Connector offers different save modes and writing options, such as Append(CREATE) or Overwrite(MERGE). Please refer to its `documentation <https://neo4j.com/docs/spark/current/writing/>`_ for more information.
 
+
+.. _TestGraphTransformer.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
 
 .. _TransformExample.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TransformExample.scala
 

--- a/docs/applications/spark.rst
+++ b/docs/applications/spark.rst
@@ -88,9 +88,9 @@ Additionally, when importing data from GraphAr to create/update instances in Neo
 .. code:: scala
   
   // construct the GraphAr Spark reader
-  val spark_session = ...   // the spark session
+  val spark = ...   // the Spark session
   val prefix : String = ... // the prefix of the file path
-  val reader = new VertexReader(prefix, vertex_info, spark_session)
+  val reader = new VertexReader(prefix, vertex_info, spark)
 
   // reading chunks for all property groups
   val vertex_df = reader.readAllVertexPropertyGroups(false)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@
    applications/out-of-core.rst
    applications/bgl.rst
    applications/graphscope.rst
+   applications/spark.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/user-guide/spark-lib.rst
+++ b/docs/user-guide/spark-lib.rst
@@ -22,6 +22,8 @@ The GraphAr Spark library can be used in a range of scenarios:
 - Transforming GAR data between different adjList types (e.g., from COO to CSR).
 - Modifying existing GAR data (e.g., adding new vertices/edges).
 
+For more information on its usage, please refer to the `applications <../applications/spark.html>`_.
+
 
 Get GraphAr Spark Library
 ------------------------------

--- a/docs/user-guide/spark-lib.rst
+++ b/docs/user-guide/spark-lib.rst
@@ -173,8 +173,12 @@ To utilize the GAR Spark reader, please refer to the following example code.
 See `TestReader.scala`_ for the complete example.
 
 
-Graph Transformer
+Graph-level APIs
 ``````````````````
+To improve the usability of the GraphAr Spark library, a set of APIs are provided to allow users to easily perform operations such as reading, writing, and transforming data at the graph level. These APIs are fairly easy to use, while the previous methods of using reader, writer and information classes are more flexibly and can be highly customized.
+
+The Graph Reader is a helper object which enables users to read all the chunk files from GraphAr for a single graph. The only input required is a GraphInfo object or the path to the information yaml file. On successful completion, it returns a set of vertex DataFrames and edge DataFrames, each of which can be accessed by specifying the vertex/edge label. The Graph Writer is used for writing all vertex DataFrames and edge DataFrames of a graph to generate GraphAr chunk files. For more details, please refer to the `API Reference <../reference/spark-api/index.html>`_ .
+
 The Graph Transformer is a helper object in the GraphAr Spark library, designed to assist with data transformation at the graph level. It takes two GraphInfo objects (or paths of two yaml files) as inputs: one for the source graph, and one for the destination graph. The transformer will then load data from existing GAR files for the source graph, utilizing the GraphAr Spark Reader and the meta data defined in the source GraphInfo. After reorganizing the data according to the destination GraphInfo, it generates new GAR chunk files with the GraphAr Spark Writer.
 
 .. code:: scala

--- a/docs/user-guide/spark-lib.rst
+++ b/docs/user-guide/spark-lib.rst
@@ -210,6 +210,7 @@ For more information on usage, please refer to the examples:
 
 - `ComputeExample.scala`_  includes an example for constructing the GraphX graph from GAR files and executing a connected-components computation.
 - `TransformExample.scala`_ shows an example for graph data conversion between different file types or different adjList types.
+- `Neo4j2GraphAr.scala`_ and `GraphAr2Neo4j.scala`_ are examples to conduct data importing/exporting for Neo4j.
 
 
 .. _TestGraphInfo.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -225,3 +226,7 @@ For more information on usage, please refer to the examples:
 .. _ComputeExample.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/ComputeExample.scala
 
 .. _TransformExample.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/TransformExample.scala
+
+.. _Neo4j2GraphAr.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+
+.. _GraphAr2Neo4j.scala: https://github.com/alibaba/GraphAr/blob/main/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -97,6 +97,11 @@
             <version>${cupid.sdk.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-connector-apache-spark_2.12</artifactId>
+            <version>5.0.0_for_spark_3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
@@ -15,6 +15,8 @@
 
 package com.alibaba.graphar
 
+import com.alibaba.graphar.utils.FileSystem
+
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
@@ -371,7 +373,7 @@ class EdgeInfo() {
     }
     str = prefix + getAdjListPrefix(adj_list_type) + str + "part" +
         vertex_chunk_index.toString() + "/chunk" + chunk_index.toString()
-    return str
+    return FileSystem.toValidFileName(str)
   }
 
   /** Get path prefix of adj list property group of certain vertex chunk.
@@ -399,7 +401,7 @@ class EdgeInfo() {
     }
     str = prefix + getAdjListPrefix(adj_list_type) + str + "part" +
       vertex_chunk_index.toString() + "/"
-    return str
+    return FileSystem.toValidFileName(str)
   }
 
   /** Get the path prefix of the property group chunk for the given
@@ -424,7 +426,7 @@ class EdgeInfo() {
       str +=  "/"
     }
     str = prefix + getAdjListPrefix(adj_list_type) + str
-    return str
+    return FileSystem.toValidFileName(str)
   }
 }
 

--- a/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
@@ -15,8 +15,6 @@
 
 package com.alibaba.graphar
 
-import com.alibaba.graphar.utils.FileSystem
-
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
@@ -373,7 +371,7 @@ class EdgeInfo() {
     }
     str = prefix + getAdjListPrefix(adj_list_type) + str + "part" +
         vertex_chunk_index.toString() + "/chunk" + chunk_index.toString()
-    return FileSystem.toValidFileName(str)
+    return str
   }
 
   /** Get path prefix of adj list property group of certain vertex chunk.
@@ -401,7 +399,7 @@ class EdgeInfo() {
     }
     str = prefix + getAdjListPrefix(adj_list_type) + str + "part" +
       vertex_chunk_index.toString() + "/"
-    return FileSystem.toValidFileName(str)
+    return str
   }
 
   /** Get the path prefix of the property group chunk for the given
@@ -426,7 +424,7 @@ class EdgeInfo() {
       str +=  "/"
     }
     str = prefix + getAdjListPrefix(adj_list_type) + str
-    return FileSystem.toValidFileName(str)
+    return str
   }
 }
 

--- a/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
@@ -37,6 +37,8 @@ object GarType extends Enumeration{
   val DOUBLE = Value(5)
   /** UTF8 variable-length string */
   val STRING = Value(6)
+  /** Array of same type */
+  val ARRAY = Value(7)
 
   /** Data type in gar to string.
    *
@@ -51,6 +53,7 @@ object GarType extends Enumeration{
     case GarType.FLOAT => "float"
     case GarType.DOUBLE => "double"
     case GarType.STRING => "string"
+    case GarType.ARRAY => "array"
     case _ => throw new IllegalArgumentException
   }
 
@@ -67,6 +70,7 @@ object GarType extends Enumeration{
     case "float" => GarType.FLOAT
     case "double" => GarType.DOUBLE
     case "string" => GarType.STRING
+    case "array" => GarType.ARRAY
     case _ => throw new IllegalArgumentException
   }
 }

--- a/spark/src/main/scala/com/alibaba/graphar/VertexInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/VertexInfo.scala
@@ -15,8 +15,6 @@
 
 package com.alibaba.graphar
 
-import com.alibaba.graphar.utils.FileSystem
-
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
@@ -194,7 +192,7 @@ class VertexInfo() {
     } else {
       str = property_group.getPrefix
     }
-    return FileSystem.toValidFileName(prefix + str + "chunk" + chunk_index.toString())
+    return prefix + str + "chunk" + chunk_index.toString()
   }
 
   /** Get the path prefix for the specified property group.
@@ -218,7 +216,7 @@ class VertexInfo() {
     } else {
       str = property_group.getPrefix
     }
-    return FileSystem.toValidFileName(prefix + str)
+    return prefix + str
   }
 }
 

--- a/spark/src/main/scala/com/alibaba/graphar/VertexInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/VertexInfo.scala
@@ -15,6 +15,8 @@
 
 package com.alibaba.graphar
 
+import com.alibaba.graphar.utils.FileSystem
+
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
@@ -192,7 +194,7 @@ class VertexInfo() {
     } else {
       str = property_group.getPrefix
     }
-    return prefix + str + "chunk" + chunk_index.toString()
+    return FileSystem.toValidFileName(prefix + str + "chunk" + chunk_index.toString())
   }
 
   /** Get the path prefix for the specified property group.
@@ -216,7 +218,7 @@ class VertexInfo() {
     } else {
       str = property_group.getPrefix
     }
-    return prefix + str;
+    return FileSystem.toValidFileName(prefix + str)
   }
 }
 

--- a/spark/src/main/scala/com/alibaba/graphar/datasources/GarTable.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/datasources/GarTable.scala
@@ -84,7 +84,11 @@ case class GarTable(name: String,
 
     // case st: StructType => st.forall { f => supportsDataType(f.dataType) }
 
-    // case ArrayType(elementType, _) => supportsDataType(elementType)
+    case ArrayType(elementType, _) => formatName match {
+      case "orc" => supportsDataType(elementType)
+      case "parquet" => supportsDataType(elementType)
+      case _ => false
+    }
 
     // case MapType(keyType, valueType, _) =>
     //   supportsDataType(keyType) && supportsDataType(valueType)

--- a/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
@@ -186,18 +186,11 @@ class EdgeWriter(prefix: String, edgeInfo: EdgeInfo, adjListType: AdjListType.Va
       throw new IllegalArgumentException
     }
 
-    val property_list = ArrayBuffer[String]()
-    val p_it = propertyGroup.getProperties().iterator
-    while (p_it.hasNext()) {
-      val property = p_it.next()
-      property_list += "`" + property.getName() + "`"
-    }
-    var chunk_index: Long = 0
-    for (chunk <- chunks) {
-      val output_prefix = prefix + edgeInfo.getPropertyGroupPathPrefix(propertyGroup, adjListType, chunk_index)
-      val property_group_chunk = chunk.select(property_list.map(col): _*)
-      FileSystem.writeDataFrame(property_group_chunk, propertyGroup.getFile_type(), output_prefix)
-      chunk_index = chunk_index + 1
+    val propertyList = ArrayBuffer[String]()
+    val pIter = propertyGroup.getProperties().iterator
+    while (pIter.hasNext()) {
+      val property = pIter.next()
+      propertyList += "`" + property.getName() + "`"
     }
     val propetyGroupDf = edgeDfAndOffsetDf._1.select(propertyList.map(col): _*)
     val outputPrefix = prefix + edgeInfo.getPropertyGroupPathPrefix(propertyGroup, adjListType)
@@ -220,5 +213,4 @@ class EdgeWriter(prefix: String, edgeInfo: EdgeInfo, adjListType: AdjListType.Va
     writeEdgeProperties()
   }
 }
-
 

--- a/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
@@ -186,11 +186,18 @@ class EdgeWriter(prefix: String, edgeInfo: EdgeInfo, adjListType: AdjListType.Va
       throw new IllegalArgumentException
     }
 
-    val propertyList = ArrayBuffer[String]()
-    val pIter = propertyGroup.getProperties().iterator
-    while (pIter.hasNext()) {
-      val property = pIter.next()
-      propertyList += "`" + property.getName() + "`"
+    val property_list = ArrayBuffer[String]()
+    val p_it = propertyGroup.getProperties().iterator
+    while (p_it.hasNext()) {
+      val property = p_it.next()
+      property_list += "`" + property.getName() + "`"
+    }
+    var chunk_index: Long = 0
+    for (chunk <- chunks) {
+      val output_prefix = prefix + edgeInfo.getPropertyGroupPathPrefix(propertyGroup, adjListType, chunk_index)
+      val property_group_chunk = chunk.select(property_list.map(col): _*)
+      FileSystem.writeDataFrame(property_group_chunk, propertyGroup.getFile_type(), output_prefix)
+      chunk_index = chunk_index + 1
     }
     val propetyGroupDf = edgeDfAndOffsetDf._1.select(propertyList.map(col): _*)
     val outputPrefix = prefix + edgeInfo.getPropertyGroupPathPrefix(propertyGroup, adjListType)

--- a/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
@@ -38,7 +38,7 @@ class GraphAr2Neo4jSuite extends AnyFunSuite {
     .config("spark.master", "local")
     .getOrCreate()
 
-  test("read vertices from GraphAr and write to Neo4j") {
+  test("read Person vertices from GraphAr and write to Neo4j") {
     // read vertex info yaml
     val file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
     val vertex_yaml_path = new Path(file_path)
@@ -61,11 +61,91 @@ class GraphAr2Neo4jSuite extends AnyFunSuite {
     vertex_df.show()
     vertex_df.printSchema()
 
-    // use the dataframe to insert/update vertices to Neo4j
-    /*vertex_df.write.format("org.neo4j.spark.DataSource")
-      .mode(SaveMode.Overwrite)
-      .option("labels", ":Person")
-      .option("node.keys", "name")
-      .save() */
+    // group vertices with the same labels together
+    val labels_array = vertex_df.select("<labels>").distinct.collect.flatMap(_.toSeq)
+    val vertex_df_array = labels_array.map(labels => vertex_df.where(vertex_df("<labels>") === labels))
+
+    // each time write a group of vertices to Neo4j
+    vertex_df_array.foreach(df => {
+      // construct the string for labels
+      val labels = df.first().getAs[Seq[String]]("<labels>")
+      var str = ""
+      labels.foreach(label => {str += ":" + label})
+
+      // write the vertices to Neo4j
+      df.drop("<id>").drop("<labels>")
+      .write.format("org.neo4j.spark.DataSource")
+      .mode(SaveMode.Append)
+      .option("labels", str)
+      .save()
+    })
   }
+
+  test("read edges from GraphAr and write to Neo4j") {
+    val spark_session = SparkSession.builder()
+      .enableHiveSupport()
+      .master("local[*]")
+      .getOrCreate()
+
+    // read person dataframe
+    val person_file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
+    val person_yaml_path = new Path(person_file_path)
+    val fs = FileSystem.get(person_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
+    val person_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
+    val person_info = person_yaml.load(fs.open(person_yaml_path)).asInstanceOf[VertexInfo]
+
+    val prefix : String = "/tmp/neo4j/"
+    val person_reader = new VertexReader(prefix, person_info, spark_session)
+    val person_df = person_reader.readAllVertexPropertyGroups(true)
+    person_df.show()
+
+    // read movie dataframe
+    val movie_file_path = getClass.getClassLoader.getResource("gar-test/neo4j/movie.vertex.yml").getPath
+    val movie_yaml_path = new Path(movie_file_path)
+    val movie_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
+    val movie_info = movie_yaml.load(fs.open(movie_yaml_path)).asInstanceOf[VertexInfo]
+
+    val movie_reader = new VertexReader(prefix, movie_info, spark_session)
+    val movie_df = movie_reader.readAllVertexPropertyGroups(true)
+    movie_df.show()
+
+    // read Person->Produced->Movie edges
+    val edge_file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath
+    val edge_yaml_path = new Path(edge_file_path)
+    val edge_yaml = new Yaml(new Constructor(classOf[EdgeInfo]))
+    val edge_info = edge_yaml.load(fs.open(edge_yaml_path)).asInstanceOf[EdgeInfo]
+
+    val adj_list_type = AdjListType.ordered_by_source
+    val reader = new EdgeReader(prefix, edge_info, adj_list_type, spark)
+    val edge_df = reader.readEdges(false)
+    edge_df.show()
+    
+    // join the edge dataframe with the two vertex dataframes to get information of src & dst
+    person_df.createOrReplaceTempView("src_vertex")
+    movie_df.createOrReplaceTempView("dst_vertex")
+    edge_df.createOrReplaceTempView("edge")
+    val srcCol = GeneralParams.srcIndexCol;
+    val dstCol = GeneralParams.dstIndexCol;
+    val indexCol = GeneralParams.vertexIndexCol;
+    val edge_df_with_src = spark.sql(f"select src_vertex.`name` as `person_name`, edge.* from edge inner join src_vertex on src_vertex.`$indexCol`=edge.`$srcCol`")
+    edge_df_with_src.createOrReplaceTempView("edge")
+    val edge_df_with_src_dst = spark.sql(f"select dst_vertex.`title` as `movie_title`, edge.* from edge inner join dst_vertex on dst_vertex.`$indexCol`=edge.`$dstCol`")
+    edge_df_with_src_dst.show()
+
+    // write the edges to Neo4j
+    edge_df_with_src_dst
+      .write.format("org.neo4j.spark.DataSource")
+      .mode(SaveMode.Append)
+      .option("relationship", "PRODUCED")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.labels", ":Person")
+      .option("relationship.source.save.mode", "match")
+      .option("relationship.source.node.keys", "person_name:name")
+      .option("relationship.target.labels", ":Movie")
+      .option("relationship.target.save.mode", "match")
+      .option("relationship.target.node.keys", "movie_title:title")
+      .option("relationship.properties", "")
+      .save()
+  }
+  
 }

--- a/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
@@ -24,9 +24,8 @@ import org.yaml.snakeyaml.constructor.Constructor
 import scala.beans.BeanProperty
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.apache.hadoop.fs.{Path, FileSystem}
-import org.scalatest.funsuite.AnyFunSuite
 
-class GraphAr2Neo4jSuite extends AnyFunSuite {
+class GraphAr2Neo4jExample {
   // connect to the Neo4j instance
   val spark = SparkSession.builder()
     .config("neo4j.url", "bolt://localhost:7687")
@@ -36,7 +35,8 @@ class GraphAr2Neo4jSuite extends AnyFunSuite {
     .config("spark.master", "local")
     .getOrCreate()
 
-  test("read Person vertices from GraphAr and write to Neo4j") {
+  // read Person vertices from GraphAr and write to Neo4j
+  def testWriteVerticesToNeo4j(): Unit = {
     // read vertex info yaml
     val file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
     val vertex_yaml_path = new Path(file_path)
@@ -80,7 +80,8 @@ class GraphAr2Neo4jSuite extends AnyFunSuite {
     })
   }
 
-  test("read edges from GraphAr and write to Neo4j") {
+  // read edges from GraphAr and write to Neo4j
+  def testWriteEdgesToNeo4j(): Unit = {
     val spark_session = SparkSession.builder()
       .enableHiveSupport()
       .master("local[*]")

--- a/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
@@ -16,9 +16,7 @@
 package com.alibaba.graphar
 
 import com.alibaba.graphar.datasources._
-import com.alibaba.graphar.utils.IndexGenerator
 import com.alibaba.graphar.reader.{VertexReader, EdgeReader}
-import com.alibaba.graphar.writer.{VertexWriter, EdgeWriter}
 
 import java.io.{File, FileInputStream}
 import org.yaml.snakeyaml.Yaml
@@ -75,8 +73,9 @@ class GraphAr2Neo4jSuite extends AnyFunSuite {
       // write the vertices to Neo4j
       df.drop("<id>").drop("<labels>")
       .write.format("org.neo4j.spark.DataSource")
-      .mode(SaveMode.Append)
+      .mode(SaveMode.Overwrite)
       .option("labels", str)
+      .option("node.keys", "name")
       .save()
     })
   }
@@ -135,7 +134,7 @@ class GraphAr2Neo4jSuite extends AnyFunSuite {
     // write the edges to Neo4j
     edge_df_with_src_dst
       .write.format("org.neo4j.spark.DataSource")
-      .mode(SaveMode.Append)
+      .mode(SaveMode.Overwrite)
       .option("relationship", "PRODUCED")
       .option("relationship.save.strategy", "keys")
       .option("relationship.source.labels", ":Person")

--- a/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
@@ -1,0 +1,71 @@
+/** Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.graphar
+
+import com.alibaba.graphar.datasources._
+import com.alibaba.graphar.utils.IndexGenerator
+import com.alibaba.graphar.reader.{VertexReader, EdgeReader}
+import com.alibaba.graphar.writer.{VertexWriter, EdgeWriter}
+
+import java.io.{File, FileInputStream}
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+import scala.beans.BeanProperty
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.hadoop.fs.{Path, FileSystem}
+import org.scalatest.funsuite.AnyFunSuite
+
+class GraphAr2Neo4jSuite extends AnyFunSuite {
+  // connect to the Neo4j instance
+  val spark = SparkSession.builder()
+    .config("neo4j.url", "bolt://localhost:7687")
+    .config("neo4j.authentication.type", "basic")
+    .config("neo4j.authentication.basic.username", sys.env.get("Neo4j_USR").get)
+    .config("neo4j.authentication.basic.password", sys.env.get("Neo4j_PWD").get)
+    .config("spark.master", "local")
+    .getOrCreate()
+
+  test("read vertices from GraphAr and write to Neo4j") {
+    // read vertex info yaml
+    val file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
+    val vertex_yaml_path = new Path(file_path)
+    val fs = FileSystem.get(vertex_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
+    val vertex_input = fs.open(vertex_yaml_path)
+    val vertex_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
+    val vertex_info = vertex_yaml.load(vertex_input).asInstanceOf[VertexInfo]
+
+    // construct the vertex reader
+    val spark_session = SparkSession.builder()
+      .enableHiveSupport()
+      .master("local[*]")
+      .getOrCreate()
+    val prefix : String = "/tmp/neo4j/"
+    val reader = new VertexReader(prefix, vertex_info, spark_session)
+
+    // reading chunks for all property groups
+    val vertex_df = reader.readAllVertexPropertyGroups(false)
+    // display the DataFrame and its schema
+    vertex_df.show()
+    vertex_df.printSchema()
+
+    // use the dataframe to insert/update vertices to Neo4j
+    /*vertex_df.write.format("org.neo4j.spark.DataSource")
+      .mode(SaveMode.Overwrite)
+      .option("labels", ":Person")
+      .option("node.keys", "name")
+      .save() */
+  }
+}

--- a/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/GraphAr2Neo4j.scala
@@ -38,20 +38,12 @@ class GraphAr2Neo4jExample {
   // read Person vertices from GraphAr and write to Neo4j
   def testWriteVerticesToNeo4j(): Unit = {
     // read vertex info yaml
-    val file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
-    val vertex_yaml_path = new Path(file_path)
-    val fs = FileSystem.get(vertex_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
-    val vertex_input = fs.open(vertex_yaml_path)
-    val vertex_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
-    val vertex_info = vertex_yaml.load(vertex_input).asInstanceOf[VertexInfo]
+    val vertex_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
+    val vertex_info = VertexInfo.loadVertexInfo(vertex_yaml, spark)
 
     // construct the vertex reader
-    val spark_session = SparkSession.builder()
-      .enableHiveSupport()
-      .master("local[*]")
-      .getOrCreate()
     val prefix : String = "/tmp/neo4j/"
-    val reader = new VertexReader(prefix, vertex_info, spark_session)
+    val reader = new VertexReader(prefix, vertex_info, spark)
 
     // reading chunks for all property groups
     val vertex_df = reader.readAllVertexPropertyGroups(false)
@@ -82,38 +74,26 @@ class GraphAr2Neo4jExample {
 
   // read edges from GraphAr and write to Neo4j
   def testWriteEdgesToNeo4j(): Unit = {
-    val spark_session = SparkSession.builder()
-      .enableHiveSupport()
-      .master("local[*]")
-      .getOrCreate()
-
     // read person dataframe
-    val person_file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
-    val person_yaml_path = new Path(person_file_path)
-    val fs = FileSystem.get(person_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
-    val person_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
-    val person_info = person_yaml.load(fs.open(person_yaml_path)).asInstanceOf[VertexInfo]
+    val person_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
+    val person_info = VertexInfo.loadVertexInfo(person_yaml, spark)
 
     val prefix : String = "/tmp/neo4j/"
-    val person_reader = new VertexReader(prefix, person_info, spark_session)
+    val person_reader = new VertexReader(prefix, person_info, spark)
     val person_df = person_reader.readAllVertexPropertyGroups(true)
     person_df.show()
 
     // read movie dataframe
-    val movie_file_path = getClass.getClassLoader.getResource("gar-test/neo4j/movie.vertex.yml").getPath
-    val movie_yaml_path = new Path(movie_file_path)
-    val movie_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
-    val movie_info = movie_yaml.load(fs.open(movie_yaml_path)).asInstanceOf[VertexInfo]
+    val movie_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/movie.vertex.yml").getPath
+    val movie_info = VertexInfo.loadVertexInfo(movie_yaml, spark)
 
-    val movie_reader = new VertexReader(prefix, movie_info, spark_session)
+    val movie_reader = new VertexReader(prefix, movie_info, spark)
     val movie_df = movie_reader.readAllVertexPropertyGroups(true)
     movie_df.show()
 
     // read Person->Produced->Movie edges
-    val edge_file_path = getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath
-    val edge_yaml_path = new Path(edge_file_path)
-    val edge_yaml = new Yaml(new Constructor(classOf[EdgeInfo]))
-    val edge_info = edge_yaml.load(fs.open(edge_yaml_path)).asInstanceOf[EdgeInfo]
+    val edge_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath
+    val edge_info = EdgeInfo.loadEdgeInfo(edge_yaml, spark)
 
     val adj_list_type = AdjListType.ordered_by_source
     val reader = new EdgeReader(prefix, edge_info, adj_list_type, spark)

--- a/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
@@ -47,11 +47,8 @@ class Neo4j2GraphArExample{
     person_df.printSchema()
 
     // read vertex info yaml
-    val vertex_yaml_path = new Path(getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath)
-    val fs = FileSystem.get(vertex_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
-    val vertex_input = fs.open(vertex_yaml_path)
-    val vertex_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
-    val vertex_info = vertex_yaml.load(vertex_input).asInstanceOf[VertexInfo]
+    val vertex_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath
+    val vertex_info = VertexInfo.loadVertexInfo(vertex_yaml, spark)
 
     // generate vertex index column for vertex dataframe
     val person_df_with_index = IndexGenerator.generateVertexIndexColumn(person_df)
@@ -75,11 +72,8 @@ class Neo4j2GraphArExample{
     movie_df.printSchema()
 
     // read vertex info yaml
-    val vertex_yaml_path = new Path(getClass.getClassLoader.getResource("gar-test/neo4j/movie.vertex.yml").getPath)
-    val fs = FileSystem.get(vertex_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
-    val vertex_input = fs.open(vertex_yaml_path)
-    val vertex_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
-    val vertex_info = vertex_yaml.load(vertex_input).asInstanceOf[VertexInfo]
+    val vertex_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/movie.vertex.yml").getPath
+    val vertex_info = VertexInfo.loadVertexInfo(vertex_yaml, spark)
 
     // generate vertex index column for vertex dataframe
     val movie_df_with_index = IndexGenerator.generateVertexIndexColumn(movie_df)
@@ -124,11 +118,8 @@ class Neo4j2GraphArExample{
     edge_df_with_src_dst_index.show()
 
     // read edge info yaml
-    val edge_yaml_path = new Path(getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath)
-    val fs = FileSystem.get(edge_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
-    val edge_input = fs.open(edge_yaml_path)
-    val edge_yaml = new Yaml(new Constructor(classOf[EdgeInfo]))
-    val edge_info = edge_yaml.load(edge_input).asInstanceOf[EdgeInfo]
+    val edge_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath
+    val edge_info = EdgeInfo.loadVertexInfo(edge_yaml, spark)
 
     // create writer object for the DataFrame with indices
     val prefix : String = "/tmp/neo4j/"

--- a/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
@@ -1,0 +1,113 @@
+/** Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.graphar
+
+import com.alibaba.graphar.datasources._
+import com.alibaba.graphar.utils.IndexGenerator
+import com.alibaba.graphar.reader.{VertexReader, EdgeReader}
+import com.alibaba.graphar.writer.{VertexWriter, EdgeWriter}
+
+import java.io.{File, FileInputStream}
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+import scala.beans.BeanProperty
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.hadoop.fs.{Path, FileSystem}
+import org.scalatest.funsuite.AnyFunSuite
+
+class Neo4j2GraphArSuite extends AnyFunSuite {
+  // connect to the Neo4j instance
+  val spark = SparkSession.builder()
+    .config("neo4j.url", "bolt://localhost:7687")
+    .config("neo4j.authentication.type", "basic")
+    .config("neo4j.authentication.basic.username", sys.env.get("Neo4j_USR").get)
+    .config("neo4j.authentication.basic.password", sys.env.get("Neo4j_PWD").get)
+    .config("spark.master", "local")
+    .getOrCreate()
+
+  test("read vertices from Neo4j and write to GraphAr") {
+    // read vertices with label "Person" from Neo4j as a DataFrame
+    val vertex_df = spark.read.format("org.neo4j.spark.DataSource")
+      .option("labels", "Person")
+      .load()
+    // display the DataFrame and its schema
+    vertex_df.show()
+    vertex_df.printSchema()
+
+    // read vertex info yaml
+    val vertex_yaml_path = new Path(getClass.getClassLoader.getResource("gar-test/neo4j/person.vertex.yml").getPath)
+    val fs = FileSystem.get(vertex_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
+    val vertex_input = fs.open(vertex_yaml_path)
+    val vertex_yaml = new Yaml(new Constructor(classOf[VertexInfo]))
+    val vertex_info = vertex_yaml.load(vertex_input).asInstanceOf[VertexInfo]
+
+    // generate vertex index column for vertex dataframe
+    val vertex_df_with_index = IndexGenerator.generateVertexIndexColumn(vertex_df)
+
+    // create writer object for person
+    val prefix : String = "/tmp/neo4j/"
+    val writer = new VertexWriter(prefix, vertex_info, vertex_df_with_index)
+
+    // use the DataFrame to generate GAR files
+    writer.writeVertexProperties()
+  }
+
+  test("read edges from Neo4j and write to GraphAr") {
+    // read vertices with label "Person" from Neo4j as a DataFrame
+    val person_df = spark.read.format("org.neo4j.spark.DataSource")
+      .option("labels", "Person")
+      .load()
+    // read vertices with label "Movie" from Neo4j as a DataFrame
+    val movie_df = spark.read.format("org.neo4j.spark.DataSource")
+      .option("labels", "Movie")
+      .load()
+
+    // read edges with type "Person"->"PRODUCED"->"Movie" from Neo4j as a DataFrame
+    val edge_df = spark.read.format("org.neo4j.spark.DataSource")
+        .option("relationship", "PRODUCED")
+        .option("relationship.source.labels", "Person")
+        .option("relationship.target.labels", "Movie")
+        .load()
+    // display the DataFrame and its schema
+    edge_df.show()
+    edge_df.printSchema()
+
+    // construct the Person vertex mapping with person_df
+    val person_vertex_mapping = IndexGenerator.constructVertexIndexMapping(person_df, "<id>")
+    // construct the Movie vertex mapping with movie_df
+    val movie_vertex_mapping = IndexGenerator.constructVertexIndexMapping(movie_df, "<id>")
+
+    // generate src index and dst index for edge DataFrame with vertex mapping
+    val edge_df_with_src_index = IndexGenerator.generateSrcIndexForEdgesFromMapping(edge_df, "<source.id>", person_vertex_mapping)
+    val edge_df_with_src_dst_index = IndexGenerator.generateDstIndexForEdgesFromMapping(edge_df_with_src_index, "<target.id>", movie_vertex_mapping)
+    edge_df_with_src_dst_index.show()
+
+    // read edge info yaml
+    val edge_yaml_path = new Path(getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath)
+    val fs = FileSystem.get(edge_yaml_path.toUri(), spark.sparkContext.hadoopConfiguration)
+    val edge_input = fs.open(edge_yaml_path)
+    val edge_yaml = new Yaml(new Constructor(classOf[EdgeInfo]))
+    val edge_info = edge_yaml.load(edge_input).asInstanceOf[EdgeInfo]
+
+    // create writer object for the DataFrame with indices
+    val prefix : String = "/tmp/neo4j/"
+    val adj_list_type = AdjListType.ordered_by_source
+    val writer = new EdgeWriter(prefix, edge_info, adj_list_type, edge_df_with_src_dst_index)
+
+    // generate the adj list and properties with GAR format
+    writer.writeEdges()
+  }
+}

--- a/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
@@ -26,7 +26,7 @@ import scala.beans.BeanProperty
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.apache.hadoop.fs.{Path, FileSystem}
 
-class Neo4j2GraphArExample{
+class Neo4j2GraphArExample {
   // connect to the Neo4j instance
   val spark = SparkSession.builder()
     .config("neo4j.url", "bolt://localhost:7687")
@@ -119,7 +119,7 @@ class Neo4j2GraphArExample{
 
     // read edge info yaml
     val edge_yaml = getClass.getClassLoader.getResource("gar-test/neo4j/person_produced_movie.edge.yml").getPath
-    val edge_info = EdgeInfo.loadVertexInfo(edge_yaml, spark)
+    val edge_info = EdgeInfo.loadEdgeInfo(edge_yaml, spark)
 
     // create writer object for the DataFrame with indices
     val prefix : String = "/tmp/neo4j/"

--- a/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
@@ -17,7 +17,6 @@ package com.alibaba.graphar
 
 import com.alibaba.graphar.datasources._
 import com.alibaba.graphar.utils.IndexGenerator
-import com.alibaba.graphar.reader.{VertexReader, EdgeReader}
 import com.alibaba.graphar.writer.{VertexWriter, EdgeWriter}
 
 import java.io.{File, FileInputStream}

--- a/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
@@ -25,9 +25,8 @@ import org.yaml.snakeyaml.constructor.Constructor
 import scala.beans.BeanProperty
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.apache.hadoop.fs.{Path, FileSystem}
-import org.scalatest.funsuite.AnyFunSuite
 
-class Neo4j2GraphArSuite extends AnyFunSuite {
+class Neo4j2GraphArExample{
   // connect to the Neo4j instance
   val spark = SparkSession.builder()
     .config("neo4j.url", "bolt://localhost:7687")
@@ -37,7 +36,8 @@ class Neo4j2GraphArSuite extends AnyFunSuite {
     .config("spark.master", "local")
     .getOrCreate()
 
-  test("read Person vertices from Neo4j and write to GraphAr") {
+  // read Person vertices from Neo4j and write to GraphAr
+  def testReadPersonVerticesFromNeo4j(): Unit = {
     // read vertices with label "Person" from Neo4j as a DataFrame
     val person_df = spark.read.format("org.neo4j.spark.DataSource")
       .option("labels", "Person")
@@ -64,7 +64,8 @@ class Neo4j2GraphArSuite extends AnyFunSuite {
     writer.writeVertexProperties()
   }
 
-  test("read Movie vertices from Neo4j and write to GraphAr") {
+  // read Movie vertices from Neo4j and write to GraphAr
+  def testReadMovieVerticesFromNeo4j(): Unit = {
     // read vertices with label "Person" from Neo4j as a DataFrame
     val movie_df = spark.read.format("org.neo4j.spark.DataSource")
       .option("labels", "Movie")
@@ -91,7 +92,8 @@ class Neo4j2GraphArSuite extends AnyFunSuite {
     writer.writeVertexProperties()
   }
 
-  test("read edges from Neo4j and write to GraphAr") {
+  // read edges from Neo4j and write to GraphAr
+  def testReadEdgesFromNeo4j(): Unit = {
     // read vertices with label "Person" from Neo4j as a DataFrame
     val person_df = spark.read.format("org.neo4j.spark.DataSource")
       .option("labels", "Person")

--- a/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/Neo4j2GraphAr.scala
@@ -132,7 +132,8 @@ class Neo4j2GraphArSuite extends AnyFunSuite {
     // create writer object for the DataFrame with indices
     val prefix : String = "/tmp/neo4j/"
     val adj_list_type = AdjListType.ordered_by_source
-    val writer = new EdgeWriter(prefix, edge_info, adj_list_type, edge_df_with_src_dst_index)
+    val vertex_num = person_df.count()
+    val writer = new EdgeWriter(prefix, edge_info, adj_list_type, vertex_num, edge_df_with_src_dst_index)
 
     // generate the adj list and properties with GAR format
     writer.writeEdges()


### PR DESCRIPTION
## Proposed changes

This change add examples of migrating graph data between Neo4j and GraphAr as a key application of GraphAr. The examples are implemented based on the Neo4j Spark connector and the GraphAr Spark library, including reading graph data from Neo4j to generate GAR files, and reading from GraphAr to create/update instances in Neo4j.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

related to issue #33 
add a new data type (Array) to Spark library, related to issue #76 

