### PR TITLE
Disable jemalloc when building the bundled arrow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,7 +109,7 @@ jobs:
           body-include: '<!-- Sticky Pull Request Comment: Surge Preview build -->'
 
       - name: Commit Doc
-        if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphAr' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'alibaba/GraphAr' }}
         run: |
           git config user.email github-actions@github.com
           git config user.name github-actions

--- a/cpp/cmake/apache-arrow.cmake
+++ b/cpp/cmake/apache-arrow.cmake
@@ -72,6 +72,7 @@ function(build_arrow)
                              "-DARROW_ORC=ON"
                              "-DARROW_COMPUTE=ON"
                              "-DARROW_DATASET=ON"
+                             "-DARROW_JEMALLOC=OFF"
                              "-DARROW_WITH_SNAPPY=OFF"
                              "-DARROW_WITH_LZ4=OFF"
                              "-DARROW_WITH_ZSTD=ON"


### PR DESCRIPTION
## Proposed changes

We noticed some failure in vineyard in gar loader tests: https://github.com/v6d-io/v6d/actions/runs/4401800380/jobs/7708326106

Not sure why. But disabling jemalloc shouldn't be a big concern and it should be the easiest way for fixing the failure.

![image](https://user-images.githubusercontent.com/7144772/224920962-398a8a85-eb01-4cab-b02d-d44561f1909f.png)

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

