### PR TITLE
[Minor][C++] Fix compile warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 .idea
 .DS_store
 .cache
+.ccls-cache
 
+compile_commands.json

--- a/cpp/src/filesystem.cc
+++ b/cpp/src/filesystem.cc
@@ -155,6 +155,7 @@ Result<T> FileSystem::ReadFileToValue(const std::string& path) const noexcept {
                                        arrow_fs_->OpenInputStream(path));
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto bytes,
                                        input->Read(sizeof(T), &ret));
+  ARROW_UNUSED(bytes);
   return ret;
 }
 


### PR DESCRIPTION
## Proposed changes

minor change: fix the warning when compiling GraphAr, such as:

```
In file included from /home/yee.yi/Workspace/GraphAr/cpp/include/gar/utils/filesystem.h:23,
                 from /home/yee.yi/Workspace/GraphAr/cpp/src/filesystem.cc:26:
/home/yee.yi/Workspace/GraphAr/cpp/src/filesystem.cc: In instantiation of ‘GraphArchive::Result<T> GraphArchive::FileSystem::ReadFileToValue(const string&) const [with T = long int; GraphArchive::Result<T> = cpp::
bitwizeshift::result<long int, GraphArchive::Status>; std::string = std::__cxx11::basic_string<char>]’:
/home/yee.yi/Workspace/GraphAr/cpp/src/filesystem.cc:271:31:   required from here
/home/yee.yi/Workspace/GraphAr/cpp/src/filesystem.cc:156:45: warning: unused variable ‘bytes’ [-Wunused-variable]
  156 |   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto bytes,
      |                                             ^~~~~
/home/yee.yi/Workspace/GraphAr/cpp/include/gar/utils/result.h:87:3: note: in definition of macro ‘GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN_IMPL’
   87 |   lhs = std::move(result_name).ValueOrDie();
      |   ^~~
/home/yee.yi/Workspace/GraphAr/cpp/src/filesystem.cc:156:3: note: in expansion of macro ‘GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN’
  156 |   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto bytes,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[100%] Linking CXX shared library libgar.so
```

