### PR TITLE
[Improvement][C++] Implement the add operator for VertexIter

### DIFF
--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -205,6 +205,13 @@ class VertexIter {
     return ret;
   }
 
+  /** The add operator. */
+  VertexIter operator+(IdType offset) {
+    VertexIter ret(*this);
+    ret.cur_offset_ += offset;
+    return ret;
+  }
+
   /** The equality operator. */
   bool operator==(const VertexIter& rhs) const noexcept {
     return cur_offset_ == rhs.cur_offset_;

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -37,6 +37,7 @@ TEST_CASE("test_vertices_collection") {
       GAR_NAMESPACE::ConstructVerticesCollection(graph_info, label);
   REQUIRE(!maybe_vertices_collection.has_error());
   auto& vertices = maybe_vertices_collection.value();
+  auto count = 0;
   for (auto it = vertices.begin(); it != vertices.end(); ++it) {
     // access data through iterator directly
     std::cout << it.id() << ", id=" << it.property<int64_t>("id").value()
@@ -48,7 +49,13 @@ TEST_CASE("test_vertices_collection") {
               << ", id=" << vertex.property<int64_t>("id").value()
               << ", firstName="
               << vertex.property<std::string>("firstName").value() << std::endl;
+    count++;
   }
+  auto it_last = vertices.begin() + (count - 1);
+  std::cout << it_last.id()
+            << ", id=" << it_last.property<int64_t>("id").value()
+            << ", firstName="
+            << it_last.property<std::string>("firstName").value() << std::endl;
 }
 
 TEST_CASE("test_edges_collection", "[Slow]") {


### PR DESCRIPTION
## Proposed changes

This change implements the add operator for VertexIter, for random access of vertices in a collection.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

related to issue #78 

