### PR TITLE
[Minor] Add discord invite link and banner to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ third-party libraries may not have the same license as GraphAr.
 .. |GraphAr Docs| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
    :target: https://alibaba.github.io/GraphAr/
 
-.. |Discord | image:: https://img.shields.io/discord/1088377726634836051.svg?logo=discord&logoColor=fff&label=Discord&color=7389d8
+.. |Discord| image:: https://img.shields.io/discord/1088377726634836051.svg?logo=discord&logoColor=fff&label=Discord&color=7389d8
    :target: https://discord.gg/XPsfd4ShCu
 
 .. |Overview Pic| image:: https://alibaba.github.io/GraphAr/_images/overview.png

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 GraphAr
 ========
 
-|GraphAr CI| |Docs CI| |GraphAr Docs|
+|GraphAr CI| |Docs CI| |GraphAr Docs| |Discord|
 
 Welcome to GraphAr (short for "Graph Archive"), an open source, standardized file format for graph data storage and retrieval.
 
@@ -128,10 +128,26 @@ The Spark Library
 See `GraphAr Spark Library`_ for details about the Spark library.
 
 
-Contributing to GraphAr
-----------------------------
+Contributing
+-------------
 
-See `Contribution Guide`_ for details on submitting patches and the contribution workflow.
+Contributing Guidelines
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Read through our `contribution guidelines`_ to learn about our submission process, coding rules, and more.
+
+Code of Conduct
+^^^^^^^^^^^^^^^^
+
+Help us keep GraphAr open and inclusive. Please read and follow our `Code of Conduct`_.
+
+Community
+---------
+
+Join the conversation and help the community.
+
+- `Discord`_
+
 
 License
 -------
@@ -150,6 +166,9 @@ third-party libraries may not have the same license as GraphAr.
 
 .. |GraphAr Docs| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
    :target: https://alibaba.github.io/GraphAr/
+
+.. |Discord | image:: https://img.shields.io/discord/1088377726634836051.svg?logo=discord&logoColor=fff&label=Discord&color=7389d8
+   :target: https://discord.gg/XPsfd4ShCu
 
 .. |Overview Pic| image:: https://alibaba.github.io/GraphAr/_images/overview.png
   :width: 650
@@ -187,7 +206,11 @@ third-party libraries may not have the same license as GraphAr.
 
 .. _example files: https://github.com/GraphScope/gar-test/blob/main/ldbc_sample/
 
-.. _Contribution Guide: https://alibaba.github.io/GraphAr/user-guide/contributing.html
+.. _contribution guidelines: https://alibaba.github.io/GraphAr/user-guide/contributing.html
+
+.. _Code of Conduct: https://github.com/alibaba/GraphAr/blob/main/CODE_OF_CONDUCT.md
+
+.. _Discord: https://discord.gg/XPsfd4ShCu
 
 .. _GitHub Issues: https://github.com/alibaba/GraphAr/issues/new
 

--- a/spark/README.rst
+++ b/spark/README.rst
@@ -4,7 +4,7 @@ This directory contains the code and build system for the GraphAr Spark library.
 
 
 Building GraphAr Spark
---------------------
+----------------------
 
 System setup
 ^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ Building the API document with maven:
 The API document is generated in the directory ``spark/target/site/scaladocs``.
 
 How to use
-^^^^^^^^^^^
+-----------
 
 Please refer to our `GraphAr Spark Library Documentation`_.
 


### PR DESCRIPTION
## Proposed changes

GraphAr would use Discord as our community tool for developer and users. Add GraphAr discord server invite link and banner to README. 

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments



