### PR TITLE
[Improvement][C++] Add validation for data types for writers in C++ library

### DIFF
--- a/cpp/include/gar/utils/data_type.h
+++ b/cpp/include/gar/utils/data_type.h
@@ -85,6 +85,8 @@ class DataType {
 
   bool operator==(const DataType& other) const { return Equals(other); }
 
+  bool operator!=(const DataType& other) const { return !Equals(other); }
+
   static std::shared_ptr<arrow::DataType> DataTypeToArrowDataType(
       DataType type_id);
 

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -41,7 +41,8 @@ namespace GAR_NAMESPACE_INTERNAL {
 enum class ValidateLevel : char {
   default_validate = -1,
   no_validate = 0,
-  with_validate = 1
+  weak_validate = 1,
+  strong_validate = 2
 };
 
 /**
@@ -249,17 +250,7 @@ class EdgeChunkWriter {
       const std::shared_ptr<arrow::Table>& input_table,
       const PropertyGroup& property_group, IdType vertex_chunk_index,
       ValidateLevel validate_level = ValidateLevel::default_validate) const
-      noexcept {
-    if (validate_level == ValidateLevel::default_validate)
-      validate_level = validate_level_;
-    if (validate_level == ValidateLevel::no_validate)
-      return Status::OK();
-    if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_))
-      return Status::InvalidOperation("invalid property group");
-    GAR_RETURN_NOT_OK(
-        Validate(input_table, vertex_chunk_index, validate_level));
-    return Status::OK();
-  }
+      noexcept;
 
   /**
    * @brief Write the number of edges into the file.

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -223,6 +223,13 @@ class EdgeChunkWriter {
   }
 
   /**
+   * @brief Get the validate level.
+   *
+   * @return The validate level of this writer.
+   */
+  inline ValidateLevel GetValidateLevel() const { return validate_level_; }
+
+  /**
    * @brief Check if the writer operation for offset is allowed.
    *
    * @param input_table The input table containing data.

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -223,7 +223,7 @@ class EdgeChunkWriter {
   }
 
   /**
-   * @brief Check if the writer operation (for adj list or offset) is allowed.
+   * @brief Check if the writer operation for offset is allowed.
    *
    * @param input_table The input table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
@@ -237,20 +237,36 @@ class EdgeChunkWriter {
                       ValidateLevel::default_validate) const noexcept;
 
   /**
+   * @brief Check if the writer operation for adj list is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param vertex_chunk_index The index of the vertex chunk.
+   * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
+   * @return Status: ok or error.
+   */
+  Status Validate(const std::shared_ptr<arrow::Table>& input_table,
+                  IdType vertex_chunk_index, IdType chunk_index,
+                  ValidateLevel validate_level =
+                      ValidateLevel::default_validate) const noexcept;
+
+  /**
    * @brief Check if the writer operation (for property group) is allowed.
    *
    * @param input_table The input table containing data.
    * @param property_group The property group to write.
    * @param vertex_chunk_index The index of the vertex chunk.
+   * @param chunk_index The index of the edge chunk inside the vertex chunk.
    * @param validate_level The validate level for this operation,
    * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status Validate(
-      const std::shared_ptr<arrow::Table>& input_table,
-      const PropertyGroup& property_group, IdType vertex_chunk_index,
-      ValidateLevel validate_level = ValidateLevel::default_validate) const
-      noexcept;
+  Status Validate(const std::shared_ptr<arrow::Table>& input_table,
+                  const PropertyGroup& property_group,
+                  IdType vertex_chunk_index, IdType chunk_index,
+                  ValidateLevel validate_level =
+                      ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write the number of edges into the file.

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -84,15 +84,15 @@ Status VertexPropertyWriter::Validate(
   if (validate_level == ValidateLevel::default_validate)
     validate_level = validate_level_;
   // no validate
-  if (validate_level_ == ValidateLevel::no_validate)
+  if (validate_level == ValidateLevel::no_validate)
     return Status::OK();
   // weak validate
   if (input_table->num_rows() > vertex_info_.GetChunkSize())
     return Status::OutOfRange();
   if (!vertex_info_.ContainPropertyGroup(property_group))
-    return Status::Invalid("invalid property group");
+    return Status::InvalidOperation("invalid property group");
   if (chunk_index < 0)
-    return Status::Invalid("invalid chunk index");
+    return Status::InvalidOperation("invalid chunk index");
   // strong validate
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -207,20 +207,18 @@ Status EdgeChunkWriter::Validate(
 }
 
 Status EdgeChunkWriter::Validate(
-      const std::shared_ptr<arrow::Table>& input_table,
-      const PropertyGroup& property_group, IdType vertex_chunk_index,
-      ValidateLevel validate_level) const
-      noexcept {
-    if (validate_level == ValidateLevel::default_validate)
-      validate_level = validate_level_;
-    if (validate_level == ValidateLevel::no_validate)
-      return Status::OK();
-    if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_))
-      return Status::InvalidOperation("invalid property group");
-    GAR_RETURN_NOT_OK(
-        Validate(input_table, vertex_chunk_index, validate_level));
+    const std::shared_ptr<arrow::Table>& input_table,
+    const PropertyGroup& property_group, IdType vertex_chunk_index,
+    ValidateLevel validate_level) const noexcept {
+  if (validate_level == ValidateLevel::default_validate)
+    validate_level = validate_level_;
+  if (validate_level == ValidateLevel::no_validate)
     return Status::OK();
-  }
+  if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_))
+    return Status::InvalidOperation("invalid property group");
+  GAR_RETURN_NOT_OK(Validate(input_table, vertex_chunk_index, validate_level));
+  return Status::OK();
+}
 
 Status EdgeChunkWriter::WriteEdgesNum(IdType vertex_chunk_index,
                                       const IdType& count) const noexcept {


### PR DESCRIPTION
## Proposed changes

This update includes the implementation of various validation levels in the GraphAr C++ SDK writers. These new validation levels could ensure the consistency of data types between the data and meta info before being written.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

related to issue #127

