### PR TITLE
[BugFix][C++] Fix next_chunk() of readers in the C++ library

### DIFF
--- a/cpp/include/gar/reader/arrow_chunk_reader.h
+++ b/cpp/include/gar/reader/arrow_chunk_reader.h
@@ -236,7 +236,8 @@ class AdjListArrowChunkReader {
    */
   Status next_chunk() {
     Status st;
-    if (++chunk_index_ >= chunk_num_) {
+    ++chunk_index_;
+    while (chunk_index_ >= chunk_num_) {
       st = Status::EndOfChunk();
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
@@ -494,7 +495,8 @@ class AdjListPropertyArrowChunkReader {
    */
   Status next_chunk() {
     Status st;
-    if (++chunk_index_ >= chunk_num_) {
+    ++chunk_index_;
+    while (chunk_index_ >= chunk_num_) {
       st = Status::EndOfChunk();
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {

--- a/cpp/include/gar/reader/chunk_info_reader.h
+++ b/cpp/include/gar/reader/chunk_info_reader.h
@@ -186,7 +186,8 @@ class AdjListChunkInfoReader {
    *     error.
    */
   Status next_chunk() {
-    if (++chunk_index_ >= chunk_num_) {
+    ++chunk_index_;
+    while (chunk_index_ >= chunk_num_) {
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
         return Status::OutOfRange();
@@ -290,7 +291,8 @@ class AdjListPropertyChunkInfoReader {
    *  error.
    */
   Status next_chunk() {
-    if (++chunk_index_ >= chunk_num_) {
+    ++chunk_index_;
+    while (chunk_index_ >= chunk_num_) {
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
         return Status::OutOfRange();


### PR DESCRIPTION
## Proposed changes

When a vertex chunk has no edge, the next_chunk() function of readers for adj_list/adj_list_property may get errors since it reads a non-existing chunk.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


