### PR TITLE
Fix building arrow bug on centos8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pushd /etc/yum.repos.d/
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+        popd
         yum update -y
         yum install -y libboost-graph-dev ccache libcurl-devel openssl-devel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,14 +125,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Cache for ccache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: ${{ matrix.os }}-build-ccache-${{ hashFiles('**/git-modules.txt') }}
-        restore-keys: |
-          ${{ matrix.os }}-build-ccache-
-
     - name: Install dependencies
       run: |
         pushd /etc/yum.repos.d/
@@ -143,15 +135,10 @@ jobs:
         dnf groupinstall -y "Development Tools"
         yum install -y boost-devel libcurl-devel openssl-devel cmake
 
-    - name: CMake
+    - name: Build GraphAr
       run: |
         mkdir build
         pushd build
         cmake ../cpp
-        popd
-
-    - name: Build GraphAr
-      run: |
-        pushd build
         make -j$(nproc)
         popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
         popd
         yum update -y
-        dnf install -y "Development Tools"
+        dnf groupinstall -y "Development Tools"
         yum install -y boost-devel ccache libcurl-devel openssl-devel cmake
 
     - name: CMake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,6 @@ jobs:
       image: centos:latest
     steps:
     - uses: actions/checkout@v3
-      with:
-          submodules: true
 
     - name: Cache for ccache
       uses: actions/cache@v3
@@ -144,7 +142,7 @@ jobs:
       run: |
         mkdir build
         pushd build
-        cmake ../cpp -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
+        cmake ../cpp
         popd
 
     - name: Build GraphAr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo yum update -y
-        sudo yum install -y libboost-graph-dev ccache libcurl-devel openssl-devel
+        yum update -y
+        yum install -y libboost-graph-dev ccache libcurl-devel openssl-devel
 
     - name: CMake
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,40 @@ jobs:
         export GAR_TEST_DATA=$PWD/../testing/
         make test
 
+
+jobs:
+  GraphAr-on-centos8:
+    runs-on: ubuntu-22.04
+    container:
+      image: centos:latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          submodules: true
+
+    - name: Cache for ccache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: ${{ matrix.os }}-build-ccache-${{ hashFiles('**/git-modules.txt') }}
+        restore-keys: |
+          ${{ matrix.os }}-build-ccache-
+
+    - name: Install dependencies
+      run: |
+        sudo yum update -y
+        sudo yum install -y libboost-graph-dev ccache libcurl-devel openssl-devel
+
+    - name: CMake
+      run: |
+        mkdir build
+        pushd build
+        cmake ../cpp -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
+        popd
+
+    - name: Build GraphAr
+      run: |
+        pushd build
+        make -j$(nproc)
+        make gar-ccache-stats
+        popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         popd
         yum update -y
         dnf groupinstall -y "Development Tools"
-        yum install -y boost-devel ccache libcurl-devel openssl-devel cmake
+        yum install -y boost-devel libcurl-devel openssl-devel cmake
 
     - name: CMake
       run: |
@@ -154,5 +154,4 @@ jobs:
       run: |
         pushd build
         make -j$(nproc)
-        make gar-ccache-stats
         popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,8 @@ jobs:
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
         popd
         yum update -y
-        yum install -y boost-devel ccache libcurl-devel openssl-devel
+        dnf install -y "Development Tools"
+        yum install -y boost-devel ccache libcurl-devel openssl-devel cmake
 
     - name: CMake
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
         popd
         yum update -y
-        yum install -y libboost-graph-dev ccache libcurl-devel openssl-devel
+        yum install -y boost-devel ccache libcurl-devel openssl-devel
 
     - name: CMake
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,6 @@ jobs:
         export GAR_TEST_DATA=$PWD/../testing/
         make test
 
-
-jobs:
   GraphAr-on-centos8:
     runs-on: ubuntu-22.04
     container:

--- a/cpp/cmake/apache-arrow.cmake
+++ b/cpp/cmake/apache-arrow.cmake
@@ -79,6 +79,7 @@ function(build_arrow)
                              "-DARROW_WITH_ZLIB=OFF"
                              "-DARROW_WITH_BROTLI=OFF"
                              "-DARROW_WITH_BZ2=OFF"
+                             "-DARROW_OPENSSL_USE_SHARED=ON"
                              "-DARROW_S3=ON")
 
     set(GAR_ARROW_INCLUDE_DIR "${GAR_ARROW_PREFIX}/include" CACHE INTERNAL "arrow include directory")


### PR DESCRIPTION
## Proposed changes
The Arrow of GraphAr is building with `ARROW_OPENSSL_USE_SHARED=OFF` by default. BUT centos yum installed openssl only provide shared library, that would get `Not Found OpenSSL::SSL` error when building arrow.

this change set `ARROW_OPENSSL_USE_SHARED=ON` in arrow building configuration and add a centos8 ci to verify Graphar building process on centos.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)



