### PR TITLE
[Improvement][C++] Implement the add-assign operator for VertexIter

### DIFF
--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -213,6 +213,12 @@ class VertexIter {
     return ret;
   }
 
+  /** The add-assign operator. */
+  VertexIter& operator+=(IdType offset) {
+    cur_offset_ += offset;
+    return *this;
+  }
+
   /** The equality operator. */
   bool operator==(const VertexIter& rhs) const noexcept {
     return cur_offset_ == rhs.cur_offset_;

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -56,6 +56,17 @@ TEST_CASE("test_vertices_collection") {
             << ", id=" << it_last.property<int64_t>("id").value()
             << ", firstName="
             << it_last.property<std::string>("firstName").value() << std::endl;
+  auto it_begin = it_last + (1 - count);
+
+  auto it = vertices.begin();
+  it += (count - 1);
+  REQUIRE(it.id() == it_last.id());
+  REQUIRE(it.property<int64_t>("id").value() ==
+          it_last.property<int64_t>("id").value());
+  it += (1 - count);
+  REQUIRE(it.id() == it_begin.id());
+  REQUIRE(it.property<int64_t>("id").value() ==
+          it_begin.property<int64_t>("id").value());
 }
 
 TEST_CASE("test_edges_collection", "[Slow]") {


### PR DESCRIPTION
## Proposed changes

PR #128 implements the add operator for VertexIter for random accessing for VerticesCollection. This change implements the add-assign operator for VertexIter which modifies it in-place to avoid copy all readers in the VertexIter.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

related to issue #78 

