### PR TITLE
[C++] [Improvement] Support to get reference of property in Vertex/Edge

### DIFF
--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -66,16 +66,15 @@ class Vertex {
    */
   template <typename T>
   inline Result<T> property(const std::string& property) noexcept {
-    T ret;
     if (properties_.find(property) == properties_.end()) {
       return Status::KeyError("The property is not exist.");
     }
     try {
-      ret = std::any_cast<T>(properties_[property]);
+      T ret = std::any_cast<T>(properties_[property]);
+      return ret;
     } catch (const std::bad_any_cast& e) {
       return Status::TypeError("The property type is not match.");
     }
-    return ret;
   }
 
  private:
@@ -120,16 +119,15 @@ class Edge {
    */
   template <typename T>
   inline Result<T> property(const std::string& property) noexcept {
-    T ret;
     if (properties_.find(property) == properties_.end()) {
       return Status::KeyError("The property is not exist.");
     }
     try {
-      ret = std::any_cast<T>(properties_[property]);
+      T ret = std::any_cast<T>(properties_[property]);
+      return ret;
     } catch (const std::bad_any_cast& e) {
       return Status::TypeError("The property type is not match.");
     }
-    return ret;
   }
 
  private:

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -49,6 +49,12 @@ TEST_CASE("test_vertices_collection") {
               << ", id=" << vertex.property<int64_t>("id").value()
               << ", firstName="
               << vertex.property<std::string>("firstName").value() << std::endl;
+    // access data reference through vertex
+    REQUIRE(vertex.property<int64_t>("id").value() ==
+            vertex.property<const int64_t&>("id").value());
+    REQUIRE(vertex.property<std::string>("firstName").value() ==
+            vertex.property<const std::string&>("firstName").value());
+    REQUIRE(vertex.property<const std::string&>("id").has_error());
     count++;
   }
   auto it_last = vertices.begin() + (count - 1);
@@ -88,11 +94,18 @@ TEST_CASE("test_edges_collection", "[Slow]") {
   size_t count = 0;
   for (auto it = edges.begin(); it != end; ++it) {
     // access data through iterator directly
-    std::cout << "src=" << it.source() << ", dst=" << it.destination()
-              << std::endl;
+    std::cout << "src=" << it.source() << ", dst=" << it.destination() << " ";
+    // access data through edge
     auto edge = *it;
-    std::cout << "src=" << edge.source() << ", dst=" << edge.destination()
+    REQUIRE(edge.source() == it.source());
+    REQUIRE(edge.destination() == it.destination());
+    std::cout << "creationDate="
+              << edge.property<std::string>("creationDate").value()
               << std::endl;
+    // access data reference through edge
+    REQUIRE(edge.property<std::string>("creationDate").value() ==
+            edge.property<const std::string&>("creationDate").value());
+    REQUIRE(edge.property<const int64_t&>("creationDate").has_error());
     count++;
   }
   std::cout << "edge_count=" << count << std::endl;


### PR DESCRIPTION
## Proposed changes

This change supports to get reference of a property in Vertex/Edge, avoiding copy the value.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

related to #78 

