### PR TITLE
[C++][Improvement] Add validation of different levels for builders in C++ library

### DIFF
--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -172,6 +172,7 @@ class VerticesBuilder {
   Status Validate(
       const Vertex& v, IdType index = -1,
       ValidateLevel validate_level = ValidateLevel::default_validate) const;
+
   /**
    * @brief Add a vertex with the given index.
    *

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -50,7 +50,7 @@ Status VerticesBuilder::Validate(const Vertex& v, IdType index,
       // check if the property is contained
       if (!vertex_info_.ContainProperty(property.first))
         return Status::InvalidOperation(
-            "invalid property name which is not "
+            "invalid property name: " + property.first + ", which is not "
             "contained in the vertex info");
       // check if the property type is correct
       auto type = vertex_info_.GetPropertyType(property.first).value();

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -50,8 +50,8 @@ Status VerticesBuilder::Validate(const Vertex& v, IdType index,
       // check if the property is contained
       if (!vertex_info_.ContainProperty(property.first))
         return Status::InvalidOperation(
-            "invalid property name: " + property.first + ", which is not "
-            "contained in the vertex info");
+            "invalid property name: " + property.first +
+            ", which is not contained in the vertex info");
       // check if the property type is correct
       auto type = vertex_info_.GetPropertyType(property.first).value();
       bool invalid_type = false;

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -38,9 +38,11 @@ limitations under the License.
 #include <catch2/catch.hpp>
 
 TEST_CASE("test_vertices_builder") {
+  std::cout << "Test vertex builder" << std::endl;
   std::string root;
   REQUIRE(GetTestResourceRoot(&root).ok());
 
+  // construct vertex builder
   std::string vertex_meta_file =
       root + "/ldbc_sample/parquet/" + "person.vertex.yml";
   auto vertex_meta = GAR_NAMESPACE::Yaml::LoadFile(vertex_meta_file).value();
@@ -49,6 +51,26 @@ TEST_CASE("test_vertices_builder") {
   GAR_NAMESPACE::builder::VerticesBuilder builder(vertex_info, "/tmp/",
                                                   start_index);
 
+  // set validate level
+  REQUIRE(builder.GetValidateLevel() ==
+          GAR_NAMESPACE::ValidateLevel::no_validate);
+  builder.SetValidateLevel(GAR_NAMESPACE::ValidateLevel::strong_validate);
+  REQUIRE(builder.GetValidateLevel() ==
+          GAR_NAMESPACE::ValidateLevel::strong_validate);
+
+  // check different validate levels
+  GAR_NAMESPACE::builder::Vertex v;
+  v.AddProperty("id", "string_id");
+  REQUIRE(builder.Validate(v, -1, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
+  REQUIRE(builder.Validate(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
+  REQUIRE(builder.Validate(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate).IsInvalidOperation());
+  REQUIRE(builder.Validate(v, 0,
+                            GAR_NAMESPACE::ValidateLevel::strong_validate).IsTypeError());
+  v.AddProperty("invalid", "invalid");
+  REQUIRE(builder.Validate(v, 0).IsInvalidOperation());
+
+
+  // add vertices
   std::ifstream fp(root + "/ldbc_sample/person_0_0.csv");
   std::string line;
   getline(fp, line);
@@ -60,7 +82,6 @@ TEST_CASE("test_vertices_builder") {
     getline(readstr, name, '|');
     names.push_back(name);
   }
-  int index = 0;
   while (getline(fp, line)) {
     std::string val;
     std::istringstream readstr(line);
@@ -76,11 +97,12 @@ TEST_CASE("test_vertices_builder") {
         v.AddProperty(names[i], val);
       }
     }
-    index++;
     REQUIRE(builder.AddVertex(v).ok());
   }
+  // dump
   REQUIRE(builder.Dump().ok());
 
+  // check the number of vertices
   auto fs = arrow::fs::FileSystemFromUriOrPath(root).ValueOrDie();
   auto input =
       fs->OpenInputStream("/tmp/vertex/person/vertex_count").ValueOrDie();
@@ -90,9 +112,11 @@ TEST_CASE("test_vertices_builder") {
 }
 
 TEST_CASE("test_edges_builder") {
+  std::cout << "Test edge builder" << std::endl;
   std::string root;
   REQUIRE(GetTestResourceRoot(&root).ok());
 
+  // construct edge builder
   std::string edge_meta_file =
       root + "/ldbc_sample/parquet/" + "person_knows_person.edge.yml";
   auto edge_meta = GAR_NAMESPACE::Yaml::LoadFile(edge_meta_file).value();
@@ -100,6 +124,7 @@ TEST_CASE("test_edges_builder") {
   GAR_NAMESPACE::builder::EdgesBuilder builder(
       edge_info, "/tmp/", GraphArchive::AdjListType::ordered_by_dest, 903);
 
+  // add edges
   std::ifstream fp(root + "/ldbc_sample/person_knows_person_0_0.csv");
   std::string line;
   getline(fp, line);
@@ -128,6 +153,7 @@ TEST_CASE("test_edges_builder") {
       }
     }
   }
-  std::cout << "Test edge builder" << std::endl;
+
+  // dump
   REQUIRE(builder.Dump().ok());
 }


### PR DESCRIPTION
## Proposed changes

Similar to the GraphAr C++ SDK writers, we could add the implementation of various validation levels in the builders (`VerticesBuilder` &` EdgesBuilder`).  A strong validation level could ensure the consistency of data types between the data and meta info before being written.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

solve issue #171 

