### PR TITLE
[C++][Improvement] Redesign and unify the implementation of validation in C++ Writer/Builder

### DIFF
--- a/cpp/include/gar/utils/writer_utils.h
+++ b/cpp/include/gar/utils/writer_utils.h
@@ -28,12 +28,12 @@ enum class ValidateLevel : char {
   default_validate = 0,
   /// To skip the validation.
   no_validate = 1,
-  /// Weak validation: check if the index, count, chunk size, adj_list type or
-  /// the property group passed to the writer/builder are valid.
+  /// Weak validation: check if the index, count, adj_list type, property group
+  /// and the size of the table passed to the writer/builder are valid.
   weak_validate = 2,
   /// Strong validation: except for the weak validation, also check if the
-  /// schema (property name and data type) of the data passed to the
-  /// writer/builder are valid.
+  /// schema (including each property name and data type) of the table passed to
+  /// the writer/builder is consistent with that defined in the info.
   strong_validate = 3
 };
 

--- a/cpp/include/gar/utils/writer_utils.h
+++ b/cpp/include/gar/utils/writer_utils.h
@@ -1,0 +1,34 @@
+/** Copyright 2022 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef GAR_UTILS_WRITER_UTILS_H_
+#define GAR_UTILS_WRITER_UTILS_H_
+
+#include "gar/utils/macros.h"
+
+namespace GAR_NAMESPACE_INTERNAL {
+
+/**
+ * @brief The level for validating writing operations.
+ */
+enum class ValidateLevel : char {
+  default_validate = 0,
+  no_validate = 1,
+  weak_validate = 2,
+  strong_validate = 3
+};
+
+}  // namespace GAR_NAMESPACE_INTERNAL
+#endif  // GAR_UTILS_WRITER_UTILS_H_

--- a/cpp/include/gar/utils/writer_utils.h
+++ b/cpp/include/gar/utils/writer_utils.h
@@ -24,9 +24,16 @@ namespace GAR_NAMESPACE_INTERNAL {
  * @brief The level for validating writing operations.
  */
 enum class ValidateLevel : char {
+  /// To use the default validate level of the writer/builder.
   default_validate = 0,
+  /// To skip the validation.
   no_validate = 1,
+  /// Weak validation: check if the index, count, chunk size, adj_list type or
+  /// the property group passed to the writer/builder are valid.
   weak_validate = 2,
+  /// Strong validation: except for the weak validation, also check if the
+  /// schema (property name and data type) of the data passed to the
+  /// writer/builder are valid.
   strong_validate = 3
 };
 

--- a/cpp/include/gar/utils/writer_utils.h
+++ b/cpp/include/gar/utils/writer_utils.h
@@ -32,8 +32,8 @@ enum class ValidateLevel : char {
   /// and the size of the table passed to the writer/builder are valid.
   weak_validate = 2,
   /// Strong validation: except for the weak validation, also check if the
-  /// schema (including each property name and data type) of the table passed to
-  /// the writer/builder is consistent with that defined in the info.
+  /// schema (including each property name and data type) of the intput data
+  /// passed to the writer/builder is consistent with that defined in the info.
   strong_validate = 3
 };
 

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -39,6 +39,23 @@ namespace GAR_NAMESPACE_INTERNAL {
 /**
  * @brief The writer for vertex property group chunks.
  *
+ * Notes: For each writing operation, a validate_level could be set, which will
+ * be used to validate the data before writing. The validate_level could be:
+ *
+ * ValidateLevel::default_validate: to use the validate_level of the writer,
+ * which set through the constructor or the SetValidateLevel method;
+ *
+ * ValidateLevel::no_validate: without validation;
+ *
+ * ValidateLevel::weak_validate: to validate if the vertex count or vertex chunk
+ * index is non-negative, the property group exists and the size of input_table
+ * is not larger than the vertex chunk size;
+ *
+ * ValidateLevel::strong_validate: besides weak_validate, also validate the
+ * schema of input_table is consistent with that of property group; for writing
+ * operations without input_table, such as writing vertices number or copying
+ * file, the strong_validate is same as weak_validate.
+ *
  */
 class VertexPropertyWriter {
  public:
@@ -218,6 +235,24 @@ class VertexPropertyWriter {
 
 /**
  * @brief The writer for edge (adj list, offset and property group) chunks.
+ *
+ * Notes: For each writing operation, a validate_level could be set, which will
+ * be used to validate the data before writing. The validate_level could be:
+ *
+ * ValidateLevel::default_validate: to use the validate_level of the writer,
+ * which set through the constructor or the SetValidateLevel method;
+ *
+ * ValidateLevel::no_validate: without validation;
+ *
+ * ValidateLevel::weak_validate: to validate if the vertex/edge count or
+ * vertex/edge chunk index is non-negative, the adj_list type is valid, the
+ * property group exists and the size of input_table is not larger than the
+ * chunk size;
+ *
+ * ValidateLevel::strong_validate: besides weak_validate, also validate the
+ * schema of input_table is consistent with that of property group; for writing
+ * operations without input_table, such as writing vertices/edges number or
+ * copying file, the strong_validate is same as weak_validate.
  *
  */
 class EdgeChunkWriter {

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -92,6 +92,8 @@ class VertexPropertyWriter {
    * @param file_name The file to copy.
    * @param property_group The property group.
    * @param chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteChunk(const std::string& file_name,
@@ -165,10 +167,8 @@ class VertexPropertyWriter {
   /**
    * @brief Check if the writing vertices number opeartion is allowed.
    *
-   * @param input_table The input table containing data.
    * @param count The number of vertices.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
+   * @param validate_level The validate level for this operation.
    * @return Status: ok or error.
    */
   Status validate(const IdType& count, ValidateLevel validate_level) const
@@ -265,6 +265,7 @@ class EdgeChunkWriter {
   /**
    * @brief Write the number of edges into the file.
    *
+   * @param vertex_chunk_index The index of the vertex chunk.
    * @param count The number of edges.
    * @param validate_level The validate level for this operation,
    * which is the writer's validate level by default.

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -165,7 +165,7 @@ class VertexPropertyWriter {
 
  private:
   /**
-   * @brief Check if the writing vertices number opeartion is allowed.
+   * @brief Check if the opeartion of writing vertices number is allowed.
    *
    * @param count The number of vertices.
    * @param validate_level The validate level for this operation.
@@ -175,18 +175,18 @@ class VertexPropertyWriter {
       noexcept;
 
   /**
-   * @brief Check if the copy file as chunk opeartion is allowed.
+   * @brief Check if the opeartion of copying a file as a chunk is allowed.
    *
    * @param property_group The property group to write.
    * @param chunk_index The index of the vertex chunk.
-   * @param validate_level The validate level for this operation..
+   * @param validate_level The validate level for this operation.
    * @return Status: ok or error.
    */
   Status validate(const PropertyGroup& property_group, IdType chunk_index,
                   ValidateLevel validate_level) const noexcept;
 
   /**
-   * @brief Check if the writing chunk opeartion is allowed.
+   * @brief Check if the opeartion of writing a table as a chunk is allowed.
    *
    * @param input_table The input table containing data.
    * @param property_group The property group to write.
@@ -557,7 +557,8 @@ class EdgeChunkWriter {
 
  private:
   /**
-   * @brief Check if the writing number or copying file operation is allowed.
+   * @brief Check if the operation of writing number or copying a file is
+   * allowed.
    *
    * @param count_or_index1 The first count or index used by the operation.
    * @param count_or_index2 The second count or index used by the operation.
@@ -568,7 +569,8 @@ class EdgeChunkWriter {
                   ValidateLevel validate_level) const noexcept;
 
   /**
-   * @brief Check if the copying file operation (for property group) is allowed.
+   * @brief Check if the operation of copying a file as a property chunk is
+   * allowed.
    *
    * @param property_group The property group to write.
    * @param vertex_chunk_index The index of the vertex chunk.
@@ -581,7 +583,8 @@ class EdgeChunkWriter {
                   ValidateLevel validate_level) const noexcept;
 
   /**
-   * @brief Check if the writer operation for offset is allowed.
+   * @brief Check if the operation of writing a table as an offset chunk is
+   * allowed.
    *
    * @param input_table The input table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
@@ -593,7 +596,8 @@ class EdgeChunkWriter {
       noexcept;
 
   /**
-   * @brief Check if the writer operation for adj list is allowed.
+   * @brief Check if the operation of writing a table as an adj list chunk is
+   * allowed.
    *
    * @param input_table The input table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
@@ -606,7 +610,8 @@ class EdgeChunkWriter {
                   ValidateLevel validate_level) const noexcept;
 
   /**
-   * @brief Check if the writer operation (for property group) is allowed.
+   * @brief Check if the operation of writing a table as a property chunk is
+   * allowed.
    *
    * @param input_table The input table containing data.
    * @param property_group The property group to write.

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "gar/utils/result.h"
 #include "gar/utils/status.h"
 #include "gar/utils/utils.h"
+#include "gar/utils/writer_utils.h"
 
 // forward declaration
 namespace arrow {
@@ -34,16 +35,6 @@ class Table;
 }
 
 namespace GAR_NAMESPACE_INTERNAL {
-
-/**
- * @brief The level for validating writing operations.
- */
-enum class ValidateLevel : char {
-  default_validate = 0,
-  no_validate = 1,
-  weak_validate = 2,
-  strong_validate = 3
-};
 
 /**
  * @brief The writer for vertex property group chunks.

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -47,7 +47,10 @@ class VertexPropertyWriter {
    *
    * @param vertex_info The vertex info that describes the vertex type.
    * @param prefix The absolute prefix.
-   * @param validate_level The validate level, with no validate by default.
+   * @param validate_level The global validate level for the writer, with no
+   * validate by default. It could be ValidateLevel::no_validate,
+   * ValidateLevel::weak_validate or ValidateLevel::strong_validate, but could
+   * not be ValidateLevel::default_validate.
    */
   VertexPropertyWriter(
       const VertexInfo& vertex_info, const std::string& prefix,
@@ -55,6 +58,11 @@ class VertexPropertyWriter {
       : vertex_info_(vertex_info),
         prefix_(prefix),
         validate_level_(validate_level) {
+    if (validate_level_ == ValidateLevel::default_validate) {
+      throw std::runtime_error(
+          "default_validate is not allowed to be set as the global validate "
+          "level for VertexPropertyWriter");
+    }
     GAR_ASSIGN_OR_RAISE_ERROR(fs_, FileSystemFromUriOrPath(prefix, &prefix_));
   }
 
@@ -64,6 +72,9 @@ class VertexPropertyWriter {
    * @param validate_level The validate level to set.
    */
   inline void SetValidateLevel(const ValidateLevel& validate_level) {
+    if (validate_level == ValidateLevel::default_validate) {
+      return;
+    }
     validate_level_ = validate_level;
   }
 
@@ -217,7 +228,10 @@ class EdgeChunkWriter {
    * @param edge_info The edge info that describes the edge type.
    * @param prefix The absolute prefix.
    * @param adj_list_type The adj list type for the edges.
-   * @param validate_level The validate level, with no validate by default.
+   * @param validate_level The global validate level for the writer, with no
+   * validate by default. It could be ValidateLevel::no_validate,
+   * ValidateLevel::weak_validate or ValidateLevel::strong_validate, but could
+   * not be ValidateLevel::default_validate.
    */
   EdgeChunkWriter(
       const EdgeInfo& edge_info, const std::string& prefix,
@@ -226,6 +240,11 @@ class EdgeChunkWriter {
       : edge_info_(edge_info),
         adj_list_type_(adj_list_type),
         validate_level_(validate_level) {
+    if (validate_level_ == ValidateLevel::default_validate) {
+      throw std::runtime_error(
+          "default_validate is not allowed to be set as the global validate "
+          "level for EdgeChunkWriter");
+    }
     GAR_ASSIGN_OR_RAISE_ERROR(fs_, FileSystemFromUriOrPath(prefix, &prefix_));
     chunk_size_ = edge_info_.GetChunkSize();
     switch (adj_list_type) {
@@ -252,6 +271,9 @@ class EdgeChunkWriter {
    * @param validate_level The validate level to set.
    */
   void SetValidateLevel(const ValidateLevel& validate_level) {
+    if (validate_level == ValidateLevel::default_validate) {
+      return;
+    }
     validate_level_ = validate_level;
   }
 

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -82,8 +82,9 @@ class VertexPropertyWriter {
    * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteVerticesNum(const IdType& count, ValidateLevel validate_level =
-                       ValidateLevel::default_validate) const noexcept;
+  Status WriteVerticesNum(const IdType& count,
+                          ValidateLevel validate_level =
+                              ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Copy a file as a vertex property group chunk.
@@ -94,9 +95,9 @@ class VertexPropertyWriter {
    * @return Status: ok or error.
    */
   Status WriteChunk(const std::string& file_name,
-                    const PropertyGroup& property_group,
-                    IdType chunk_index, ValidateLevel validate_level =
-                       ValidateLevel::default_validate) const noexcept;
+                    const PropertyGroup& property_group, IdType chunk_index,
+                    ValidateLevel validate_level =
+                        ValidateLevel::default_validate) const noexcept;
   /**
    * @brief Validate and write a single property group for a
    * single vertex chunk.
@@ -109,9 +110,9 @@ class VertexPropertyWriter {
    * @return Status: ok or error.
    */
   Status WriteChunk(const std::shared_ptr<arrow::Table>& input_table,
-                    const PropertyGroup& property_group,
-                    IdType chunk_index, ValidateLevel validate_level =
-                       ValidateLevel::default_validate) const noexcept;
+                    const PropertyGroup& property_group, IdType chunk_index,
+                    ValidateLevel validate_level =
+                        ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write all property groups of a single vertex chunk
@@ -123,9 +124,10 @@ class VertexPropertyWriter {
    * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteChunk(const std::shared_ptr<arrow::Table>& input_table,
-                    IdType chunk_index, ValidateLevel validate_level =
-                       ValidateLevel::default_validate) const noexcept;
+  Status WriteChunk(
+      const std::shared_ptr<arrow::Table>& input_table, IdType chunk_index,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Write a single property group for multiple vertex chunks
@@ -138,10 +140,11 @@ class VertexPropertyWriter {
    * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteTable(const std::shared_ptr<arrow::Table>& input_table,
-                    const PropertyGroup& property_group,
-                    IdType start_chunk_index, ValidateLevel validate_level =
-                       ValidateLevel::default_validate) const noexcept;
+  Status WriteTable(
+      const std::shared_ptr<arrow::Table>& input_table,
+      const PropertyGroup& property_group, IdType start_chunk_index,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Write all property groups for multiple vertex chunks
@@ -154,11 +157,12 @@ class VertexPropertyWriter {
    * @return Status: ok or error.
    */
   Status WriteTable(const std::shared_ptr<arrow::Table>& input_table,
-                    IdType start_chunk_index, ValidateLevel validate_level =
-                       ValidateLevel::default_validate) const noexcept;
+                    IdType start_chunk_index,
+                    ValidateLevel validate_level =
+                        ValidateLevel::default_validate) const noexcept;
 
  private:
-   /**
+  /**
    * @brief Check if the writing vertices number opeartion is allowed.
    *
    * @param input_table The input table containing data.
@@ -167,10 +171,10 @@ class VertexPropertyWriter {
    * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status validate(const IdType& count,
-                  ValidateLevel validate_level) const noexcept;
+  Status validate(const IdType& count, ValidateLevel validate_level) const
+      noexcept;
 
-    /**
+  /**
    * @brief Check if the copy file as chunk opeartion is allowed.
    *
    * @param property_group The property group to write.
@@ -262,28 +266,39 @@ class EdgeChunkWriter {
    * @brief Write the number of edges into the file.
    *
    * @param count The number of edges.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteEdgesNum(IdType vertex_chunk_index, const IdType& count) const
-      noexcept;
+  Status WriteEdgesNum(IdType vertex_chunk_index, const IdType& count,
+                       ValidateLevel validate_level =
+                           ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write the number of vertices into the file.
    *
    * @param count The number of vertices.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteVerticesNum(const IdType& count) const noexcept;
+  Status WriteVerticesNum(const IdType& count,
+                          ValidateLevel validate_level =
+                              ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Copy a file as a offset chunk.
    *
    * @param file_name The file to copy.
    * @param vertex_chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteOffsetChunk(const std::string& file_name,
-                          IdType vertex_chunk_index) const noexcept;
+  Status WriteOffsetChunk(
+      const std::string& file_name, IdType vertex_chunk_index,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Copy a file as an adj list chunk.
@@ -291,11 +306,14 @@ class EdgeChunkWriter {
    * @param file_name The file to copy.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteAdjListChunk(const std::string& file_name,
-                           IdType vertex_chunk_index, IdType chunk_index) const
-      noexcept;
+                           IdType vertex_chunk_index, IdType chunk_index,
+                           ValidateLevel validate_level =
+                               ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Copy a file as an edge property group chunk.
@@ -304,11 +322,14 @@ class EdgeChunkWriter {
    * @param property_group The property group to write.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WritePropertyChunk(const std::string& file_name,
-                            const PropertyGroup& property_group,
-                            IdType vertex_chunk_index, IdType chunk_index) const
+  Status WritePropertyChunk(
+      const std::string& file_name, const PropertyGroup& property_group,
+      IdType vertex_chunk_index, IdType chunk_index,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
       noexcept;
 
   /**
@@ -316,10 +337,14 @@ class EdgeChunkWriter {
    *
    * @param input_table The table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteOffsetChunk(const std::shared_ptr<arrow::Table>& input_table,
-                          IdType vertex_chunk_index) const noexcept;
+                          IdType vertex_chunk_index,
+                          ValidateLevel validate_level =
+                              ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Validate and write the adj list chunk for an edge chunk.
@@ -327,11 +352,14 @@ class EdgeChunkWriter {
    * @param input_table The table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteAdjListChunk(const std::shared_ptr<arrow::Table>& input_table,
-                           IdType vertex_chunk_index, IdType chunk_index) const
-      noexcept;
+                           IdType vertex_chunk_index, IdType chunk_index,
+                           ValidateLevel validate_level =
+                               ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Validate and write a single edge property group for an edge chunk.
@@ -340,12 +368,15 @@ class EdgeChunkWriter {
    * @param property_group The property group to write.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WritePropertyChunk(const std::shared_ptr<arrow::Table>& input_table,
                             const PropertyGroup& property_group,
-                            IdType vertex_chunk_index, IdType chunk_index) const
-      noexcept;
+                            IdType vertex_chunk_index, IdType chunk_index,
+                            ValidateLevel validate_level =
+                                ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write all edge property groups for an edge chunk.
@@ -353,11 +384,14 @@ class EdgeChunkWriter {
    * @param input_table The table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WritePropertyChunk(const std::shared_ptr<arrow::Table>& input_table,
-                            IdType vertex_chunk_index, IdType chunk_index) const
-      noexcept;
+                            IdType vertex_chunk_index, IdType chunk_index,
+                            ValidateLevel validate_level =
+                                ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write the adj list and all property groups for an edge chunk.
@@ -365,11 +399,14 @@ class EdgeChunkWriter {
    * @param input_table The table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteChunk(const std::shared_ptr<arrow::Table>& input_table,
-                    IdType vertex_chunk_index, IdType chunk_index) const
-      noexcept;
+                    IdType vertex_chunk_index, IdType chunk_index,
+                    ValidateLevel validate_level =
+                        ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write the adj list chunks for the edges of a vertex chunk.
@@ -378,11 +415,15 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteAdjListTable(const std::shared_ptr<arrow::Table>& input_table,
-                           IdType vertex_chunk_index,
-                           IdType start_chunk_index = 0) const noexcept;
+  Status WriteAdjListTable(
+      const std::shared_ptr<arrow::Table>& input_table,
+      IdType vertex_chunk_index, IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Write chunks of a single property group for the edges of a
@@ -393,12 +434,16 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WritePropertyTable(const std::shared_ptr<arrow::Table>& input_table,
-                            const PropertyGroup& property_group,
-                            IdType vertex_chunk_index,
-                            IdType start_chunk_index = 0) const noexcept;
+  Status WritePropertyTable(
+      const std::shared_ptr<arrow::Table>& input_table,
+      const PropertyGroup& property_group, IdType vertex_chunk_index,
+      IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Write chunks of all property groups for the edges of a vertex
@@ -408,11 +453,15 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WritePropertyTable(const std::shared_ptr<arrow::Table>& input_table,
-                            IdType vertex_chunk_index,
-                            IdType start_chunk_index = 0) const noexcept;
+  Status WritePropertyTable(
+      const std::shared_ptr<arrow::Table>& input_table,
+      IdType vertex_chunk_index, IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Write chunks of the adj list and all property groups for the
@@ -422,11 +471,14 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteTable(const std::shared_ptr<arrow::Table>& input_table,
-                    IdType vertex_chunk_index,
-                    IdType start_chunk_index = 0) const noexcept;
+                    IdType vertex_chunk_index, IdType start_chunk_index = 0,
+                    ValidateLevel validate_level =
+                        ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Sort the edges, and write the adj list chunks for the edges of a
@@ -436,11 +488,15 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status SortAndWriteAdjListTable(
       const std::shared_ptr<arrow::Table>& input_table,
-      IdType vertex_chunk_index, IdType start_chunk_index = 0) const noexcept;
+      IdType vertex_chunk_index, IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Sort the edges, and write chunks of a single property group for the
@@ -451,12 +507,16 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status SortAndWritePropertyTable(
       const std::shared_ptr<arrow::Table>& input_table,
       const PropertyGroup& property_group, IdType vertex_chunk_index,
-      IdType start_chunk_index = 0) const noexcept;
+      IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Sort the edges, and write chunks of all property groups for the
@@ -466,11 +526,15 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status SortAndWritePropertyTable(
       const std::shared_ptr<arrow::Table>& input_table,
-      IdType vertex_chunk_index, IdType start_chunk_index = 0) const noexcept;
+      IdType vertex_chunk_index, IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
   /**
    * @brief Sort the edges, and write chunks of the adj list and all property
@@ -480,26 +544,52 @@ class EdgeChunkWriter {
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param start_chunk_index The start index of the edge chunks inside
    * the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status SortAndWriteTable(const std::shared_ptr<arrow::Table>& input_table,
-                           IdType vertex_chunk_index,
-                           IdType start_chunk_index = 0) const noexcept;
+  Status SortAndWriteTable(
+      const std::shared_ptr<arrow::Table>& input_table,
+      IdType vertex_chunk_index, IdType start_chunk_index = 0,
+      ValidateLevel validate_level = ValidateLevel::default_validate) const
+      noexcept;
 
  private:
+  /**
+   * @brief Check if the writing number or copying file operation is allowed.
+   *
+   * @param count_or_index1 The first count or index used by the operation.
+   * @param count_or_index2 The second count or index used by the operation.
+   * @param validate_level The validate level for this operation.
+   * @return Status: ok or error.
+   */
+  Status validate(IdType count_or_index1, IdType count_or_index2,
+                  ValidateLevel validate_level) const noexcept;
+
+  /**
+   * @brief Check if the copying file operation (for property group) is allowed.
+   *
+   * @param property_group The property group to write.
+   * @param vertex_chunk_index The index of the vertex chunk.
+   * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation.
+   * @return Status: ok or error.
+   */
+  Status validate(const PropertyGroup& property_group,
+                  IdType vertex_chunk_index, IdType chunk_index,
+                  ValidateLevel validate_level) const noexcept;
+
   /**
    * @brief Check if the writer operation for offset is allowed.
    *
    * @param input_table The input table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
+   * @param validate_level The validate level for this operation.
    * @return Status: ok or error.
    */
   Status validate(const std::shared_ptr<arrow::Table>& input_table,
-                  IdType vertex_chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
+                  IdType vertex_chunk_index, ValidateLevel validate_level) const
+      noexcept;
 
   /**
    * @brief Check if the writer operation for adj list is allowed.
@@ -507,14 +597,12 @@ class EdgeChunkWriter {
    * @param input_table The input table containing data.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
+   * @param validate_level The validate level for this operation.
    * @return Status: ok or error.
    */
   Status validate(const std::shared_ptr<arrow::Table>& input_table,
                   IdType vertex_chunk_index, IdType chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
+                  ValidateLevel validate_level) const noexcept;
 
   /**
    * @brief Check if the writer operation (for property group) is allowed.
@@ -523,15 +611,13 @@ class EdgeChunkWriter {
    * @param property_group The property group to write.
    * @param vertex_chunk_index The index of the vertex chunk.
    * @param chunk_index The index of the edge chunk inside the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
+   * @param validate_level The validate level for this operation.
    * @return Status: ok or error.
    */
   Status validate(const std::shared_ptr<arrow::Table>& input_table,
                   const PropertyGroup& property_group,
                   IdType vertex_chunk_index, IdType chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
+                  ValidateLevel validate_level) const noexcept;
 
   /**
    * @brief Construct the offset table.

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -75,21 +75,6 @@ class VertexPropertyWriter {
   inline ValidateLevel GetValidateLevel() const { return validate_level_; }
 
   /**
-   * @brief Check if the write opeartion is allowed.
-   *
-   * @param input_table The input table containing data.
-   * @param property_group The property group to write.
-   * @param chunk_index The index of the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
-   * @return Status: ok or error.
-   */
-  Status Validate(const std::shared_ptr<arrow::Table>& input_table,
-                  const PropertyGroup& property_group, IdType chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
-
-  /**
    * @brief Write the number of vertices into the file.
    *
    * @param count The number of vertices.
@@ -157,6 +142,22 @@ class VertexPropertyWriter {
                     IdType start_chunk_index) const noexcept;
 
  private:
+   /**
+   * @brief Check if the write opeartion is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param property_group The property group to write.
+   * @param chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
+   * @return Status: ok or error.
+   */
+  Status validate(const std::shared_ptr<arrow::Table>& input_table,
+                  const PropertyGroup& property_group, IdType chunk_index,
+                  ValidateLevel validate_level =
+                      ValidateLevel::default_validate) const noexcept;                    
+
+ private:
   VertexInfo vertex_info_;
   std::string prefix_;
   std::shared_ptr<FileSystem> fs_;
@@ -219,52 +220,6 @@ class EdgeChunkWriter {
    * @return The validate level of this writer.
    */
   inline ValidateLevel GetValidateLevel() const { return validate_level_; }
-
-  /**
-   * @brief Check if the writer operation for offset is allowed.
-   *
-   * @param input_table The input table containing data.
-   * @param vertex_chunk_index The index of the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
-   * @return Status: ok or error.
-   */
-  Status Validate(const std::shared_ptr<arrow::Table>& input_table,
-                  IdType vertex_chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
-
-  /**
-   * @brief Check if the writer operation for adj list is allowed.
-   *
-   * @param input_table The input table containing data.
-   * @param vertex_chunk_index The index of the vertex chunk.
-   * @param chunk_index The index of the edge chunk inside the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
-   * @return Status: ok or error.
-   */
-  Status Validate(const std::shared_ptr<arrow::Table>& input_table,
-                  IdType vertex_chunk_index, IdType chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
-
-  /**
-   * @brief Check if the writer operation (for property group) is allowed.
-   *
-   * @param input_table The input table containing data.
-   * @param property_group The property group to write.
-   * @param vertex_chunk_index The index of the vertex chunk.
-   * @param chunk_index The index of the edge chunk inside the vertex chunk.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
-   * @return Status: ok or error.
-   */
-  Status Validate(const std::shared_ptr<arrow::Table>& input_table,
-                  const PropertyGroup& property_group,
-                  IdType vertex_chunk_index, IdType chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write the number of edges into the file.
@@ -495,6 +450,52 @@ class EdgeChunkWriter {
                            IdType start_chunk_index = 0) const noexcept;
 
  private:
+   /**
+   * @brief Check if the writer operation for offset is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param vertex_chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
+   * @return Status: ok or error.
+   */
+  Status validate(const std::shared_ptr<arrow::Table>& input_table,
+                  IdType vertex_chunk_index,
+                  ValidateLevel validate_level =
+                      ValidateLevel::default_validate) const noexcept;
+
+  /**
+   * @brief Check if the writer operation for adj list is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param vertex_chunk_index The index of the vertex chunk.
+   * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
+   * @return Status: ok or error.
+   */
+  Status validate(const std::shared_ptr<arrow::Table>& input_table,
+                  IdType vertex_chunk_index, IdType chunk_index,
+                  ValidateLevel validate_level =
+                      ValidateLevel::default_validate) const noexcept;
+
+  /**
+   * @brief Check if the writer operation (for property group) is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param property_group The property group to write.
+   * @param vertex_chunk_index The index of the vertex chunk.
+   * @param chunk_index The index of the edge chunk inside the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
+   * @return Status: ok or error.
+   */
+  Status validate(const std::shared_ptr<arrow::Table>& input_table,
+                  const PropertyGroup& property_group,
+                  IdType vertex_chunk_index, IdType chunk_index,
+                  ValidateLevel validate_level =
+                      ValidateLevel::default_validate) const noexcept;
+
   /**
    * @brief Construct the offset table.
    *

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -78,9 +78,12 @@ class VertexPropertyWriter {
    * @brief Write the number of vertices into the file.
    *
    * @param count The number of vertices.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
-  Status WriteVerticesNum(const IdType& count) const noexcept;
+  Status WriteVerticesNum(const IdType& count, ValidateLevel validate_level =
+                       ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Copy a file as a vertex property group chunk.
@@ -92,7 +95,8 @@ class VertexPropertyWriter {
    */
   Status WriteChunk(const std::string& file_name,
                     const PropertyGroup& property_group,
-                    IdType chunk_index) const noexcept;
+                    IdType chunk_index, ValidateLevel validate_level =
+                       ValidateLevel::default_validate) const noexcept;
   /**
    * @brief Validate and write a single property group for a
    * single vertex chunk.
@@ -100,11 +104,14 @@ class VertexPropertyWriter {
    * @param input_table The table containing data.
    * @param property_group The property group.
    * @param chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteChunk(const std::shared_ptr<arrow::Table>& input_table,
                     const PropertyGroup& property_group,
-                    IdType chunk_index) const noexcept;
+                    IdType chunk_index, ValidateLevel validate_level =
+                       ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write all property groups of a single vertex chunk
@@ -112,10 +119,13 @@ class VertexPropertyWriter {
    *
    * @param input_table The table containing data.
    * @param chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteChunk(const std::shared_ptr<arrow::Table>& input_table,
-                    IdType chunk_index) const noexcept;
+                    IdType chunk_index, ValidateLevel validate_level =
+                       ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write a single property group for multiple vertex chunks
@@ -124,11 +134,14 @@ class VertexPropertyWriter {
    * @param input_table The table containing data.
    * @param property_group The property group.
    * @param start_chunk_index The start index of the vertex chunks.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
   Status WriteTable(const std::shared_ptr<arrow::Table>& input_table,
                     const PropertyGroup& property_group,
-                    IdType start_chunk_index) const noexcept;
+                    IdType start_chunk_index, ValidateLevel validate_level =
+                       ValidateLevel::default_validate) const noexcept;
 
   /**
    * @brief Write all property groups for multiple vertex chunks
@@ -136,26 +149,50 @@ class VertexPropertyWriter {
    *
    * @param input_table The table containing data.
    * @param start_chunk_index The start index of the vertex chunks.
-   * @return Status: ok or error.
-   */
-  Status WriteTable(const std::shared_ptr<arrow::Table>& input_table,
-                    IdType start_chunk_index) const noexcept;
-
- private:
-  /**
-   * @brief Check if the write opeartion is allowed.
-   *
-   * @param input_table The input table containing data.
-   * @param property_group The property group to write.
-   * @param chunk_index The index of the vertex chunk.
    * @param validate_level The validate level for this operation,
    * which is the writer's validate level by default.
    * @return Status: ok or error.
    */
+  Status WriteTable(const std::shared_ptr<arrow::Table>& input_table,
+                    IdType start_chunk_index, ValidateLevel validate_level =
+                       ValidateLevel::default_validate) const noexcept;
+
+ private:
+   /**
+   * @brief Check if the writing vertices number opeartion is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param count The number of vertices.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
+   * @return Status: ok or error.
+   */
+  Status validate(const IdType& count,
+                  ValidateLevel validate_level) const noexcept;
+
+    /**
+   * @brief Check if the copy file as chunk opeartion is allowed.
+   *
+   * @param property_group The property group to write.
+   * @param chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation..
+   * @return Status: ok or error.
+   */
+  Status validate(const PropertyGroup& property_group, IdType chunk_index,
+                  ValidateLevel validate_level) const noexcept;
+
+  /**
+   * @brief Check if the writing chunk opeartion is allowed.
+   *
+   * @param input_table The input table containing data.
+   * @param property_group The property group to write.
+   * @param chunk_index The index of the vertex chunk.
+   * @param validate_level The validate level for this operation.
+   * @return Status: ok or error.
+   */
   Status validate(const std::shared_ptr<arrow::Table>& input_table,
                   const PropertyGroup& property_group, IdType chunk_index,
-                  ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;
+                  ValidateLevel validate_level) const noexcept;
 
  private:
   VertexInfo vertex_info_;

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -142,7 +142,7 @@ class VertexPropertyWriter {
                     IdType start_chunk_index) const noexcept;
 
  private:
-   /**
+  /**
    * @brief Check if the write opeartion is allowed.
    *
    * @param input_table The input table containing data.
@@ -155,7 +155,7 @@ class VertexPropertyWriter {
   Status validate(const std::shared_ptr<arrow::Table>& input_table,
                   const PropertyGroup& property_group, IdType chunk_index,
                   ValidateLevel validate_level =
-                      ValidateLevel::default_validate) const noexcept;                    
+                      ValidateLevel::default_validate) const noexcept;
 
  private:
   VertexInfo vertex_info_;
@@ -450,7 +450,7 @@ class EdgeChunkWriter {
                            IdType start_chunk_index = 0) const noexcept;
 
  private:
-   /**
+  /**
    * @brief Check if the writer operation for offset is allowed.
    *
    * @param input_table The input table containing data.

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -213,7 +213,7 @@ class EdgesBuilder {
    * @return Status: ok or Status::InvalidOperation error.
    */
   Status AddEdge(const Edge& e, const ValidateLevel& validate_level =
-                                   ValidateLevel::default_validate) {
+                                    ValidateLevel::default_validate) {
     // validate
     GAR_RETURN_NOT_OK(validate(e, validate_level));
     // add an edge
@@ -293,7 +293,7 @@ class EdgesBuilder {
   }
 
  private:
-   /**
+  /**
    * @brief Get the vertex chunk index of a given edge.
    *
    * @param e The edge to add.
@@ -314,7 +314,7 @@ class EdgesBuilder {
     }
   }
 
-   /**
+  /**
    * @brief Check if adding an edge is allowed.
    *
    * @param e The edge to add.

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -209,7 +209,7 @@ class EdgesBuilder {
    *
    * @param e The edge to add.
    * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
+   * which is the builder's validate level by default.
    * @return Status: ok or Status::InvalidOperation error.
    */
   Status AddEdge(const Edge& e, const ValidateLevel& validate_level =

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -218,6 +218,19 @@ class EdgesBuilder {
   /**
    * @brief Add an edge to the collection.
    *
+   * The validate_level for this operation could be:
+   *
+   * ValidateLevel::default_validate: to use the validate_level of the builder,
+   * which set through the constructor or the SetValidateLevel method;
+   *
+   * ValidateLevel::no_validate: without validation;
+   *
+   * ValidateLevel::weak_validate: to validate if the adj_list type is valid,
+   * and the data in builder is not saved;
+   *
+   * ValidateLevel::strong_validate: besides weak_validate, also validate the
+   * schema of the edge is consistent with the info defined.
+   *
    * @param e The edge to add.
    * @param validate_level The validate level for this operation,
    * which is the builder's validate level by default.

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -147,7 +147,10 @@ class EdgesBuilder {
    * @param prefix The absolute prefix.
    * @param adj_list_type The adj list type of the edges.
    * @param num_vertices The total number of vertices for source or destination.
-   * @param validate_level The validate level, with no validate by default.
+   * @param validate_level The global validate level for the writer, with no
+   * validate by default. It could be ValidateLevel::no_validate,
+   * ValidateLevel::weak_validate or ValidateLevel::strong_validate, but could
+   * not be ValidateLevel::default_validate.
    */
   explicit EdgesBuilder(
       const EdgeInfo edge_info, const std::string& prefix,
@@ -158,6 +161,11 @@ class EdgesBuilder {
         adj_list_type_(adj_list_type),
         num_vertices_(num_vertices),
         validate_level_(validate_level) {
+    if (validate_level_ == ValidateLevel::default_validate) {
+      throw std::runtime_error(
+          "default_validate is not allowed to be set as the global validate "
+          "level for EdgesBuilder");
+    }
     edges_.clear();
     num_edges_ = 0;
     is_saved_ = false;
@@ -185,6 +193,9 @@ class EdgesBuilder {
    * @param validate_level The validate level to set.
    */
   inline void SetValidateLevel(const ValidateLevel& validate_level) {
+    if (validate_level == ValidateLevel::default_validate) {
+      return;
+    }
     validate_level_ = validate_level;
   }
 

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -196,46 +196,26 @@ class EdgesBuilder {
   inline ValidateLevel GetValidateLevel() const { return validate_level_; }
 
   /**
-   * @brief Check if adding an edge is allowed.
-   *
-   * @param e The edge to add.
-   * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
-   * @return Status: ok or status::InvalidOperation error.
+   * @brief Clear the edges in this EdgessBuilder.
    */
-  Status Validate(const Edge& e, ValidateLevel validate_level =
-                                     ValidateLevel::default_validate) const;
-
-  /**
-   * @brief Get the vertex chunk index of a given edge.
-   *
-   * @param e The edge to add.
-   * @return The vertex chunk index of the edge.
-   */
-  IdType getVertexChunkIndex(const Edge& e) {
-    switch (adj_list_type_) {
-    case AdjListType::unordered_by_source:
-      return e.GetSource() / vertex_chunk_size_;
-    case AdjListType::ordered_by_source:
-      return e.GetSource() / vertex_chunk_size_;
-    case AdjListType::unordered_by_dest:
-      return e.GetDestination() / vertex_chunk_size_;
-    case AdjListType::ordered_by_dest:
-      return e.GetDestination() / vertex_chunk_size_;
-    default:
-      return e.GetSource() / vertex_chunk_size_;
-    }
+  inline void Clear() {
+    edges_.clear();
+    num_edges_ = 0;
+    is_saved_ = false;
   }
 
   /**
    * @brief Add an edge to the collection.
    *
    * @param e The edge to add.
+   * @param validate_level The validate level for this operation,
+   * which is the writer's validate level by default.
    * @return Status: ok or Status::InvalidOperation error.
    */
-  Status AddEdge(const Edge& e) {
+  Status AddEdge(const Edge& e, const ValidateLevel& validate_level =
+                                   ValidateLevel::default_validate) {
     // validate
-    GAR_RETURN_NOT_OK(Validate(e));
+    GAR_RETURN_NOT_OK(validate(e, validate_level));
     // add an edge
     IdType vertex_chunk_index = getVertexChunkIndex(e);
     edges_[vertex_chunk_index].push_back(e);
@@ -313,6 +293,36 @@ class EdgesBuilder {
   }
 
  private:
+   /**
+   * @brief Get the vertex chunk index of a given edge.
+   *
+   * @param e The edge to add.
+   * @return The vertex chunk index of the edge.
+   */
+  IdType getVertexChunkIndex(const Edge& e) {
+    switch (adj_list_type_) {
+    case AdjListType::unordered_by_source:
+      return e.GetSource() / vertex_chunk_size_;
+    case AdjListType::ordered_by_source:
+      return e.GetSource() / vertex_chunk_size_;
+    case AdjListType::unordered_by_dest:
+      return e.GetDestination() / vertex_chunk_size_;
+    case AdjListType::ordered_by_dest:
+      return e.GetDestination() / vertex_chunk_size_;
+    default:
+      return e.GetSource() / vertex_chunk_size_;
+    }
+  }
+
+   /**
+   * @brief Check if adding an edge is allowed.
+   *
+   * @param e The edge to add.
+   * @param validate_level The validate level for this operation.
+   * @return Status: ok or status::InvalidOperation error.
+   */
+  Status validate(const Edge& e, ValidateLevel validate_level) const;
+
   /**
    * @brief Construct an array for a given property.
    *

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -183,6 +183,19 @@ class VerticesBuilder {
   /**
    * @brief Add a vertex with the given index.
    *
+   * The validate_level for this operation could be:
+   *
+   * ValidateLevel::default_validate: to use the validate_level of the builder,
+   * which set through the constructor or the SetValidateLevel method;
+   *
+   * ValidateLevel::no_validate: without validation;
+   *
+   * ValidateLevel::weak_validate: to validate if the start index and the vertex
+   * index is valid, and the data in builder is not saved;
+   *
+   * ValidateLevel::strong_validate: besides weak_validate, also validate the
+   * schema of the vertex is consistent with the info defined.
+   *
    * @param v The vertex to add.
    * @param index The given index, -1 means the next unused index.
    * @param validate_level The validate level for this operation,

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -178,7 +178,9 @@ class VerticesBuilder {
    * which is the writer's validate level by default.
    * @return Status: ok or Status::InvalidOperation error.
    */
-  Status AddVertex(Vertex& v, IdType index = -1, ValidateLevel validate_level = ValidateLevel::default_validate) {  // NOLINT
+  Status AddVertex(Vertex& v, IdType index = -1,
+                   ValidateLevel validate_level =
+                       ValidateLevel::default_validate) {  // NOLINT
     // validate
     GAR_RETURN_NOT_OK(validate(v, index, validate_level));
     // add a vertex
@@ -224,7 +226,7 @@ class VerticesBuilder {
   }
 
  private:
-   /**
+  /**
    * @brief Check if adding a vertex with the given index is allowed.
    *
    * @param v The vertex to add.
@@ -232,7 +234,8 @@ class VerticesBuilder {
    * @param validate_level The validate level for this operation.
    * @return Status: ok or Status::InvalidOperation error.
    */
-  Status validate(const Vertex& v, IdType index, ValidateLevel validate_level) const;
+  Status validate(const Vertex& v, IdType index,
+                  ValidateLevel validate_level) const;
 
   /**
    * @brief Construct an array for a given property.

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -175,7 +175,7 @@ class VerticesBuilder {
    * @param v The vertex to add.
    * @param index The given index, -1 means the next unused index.
    * @param validate_level The validate level for this operation,
-   * which is the writer's validate level by default.
+   * which is the builder's validate level by default.
    * @return Status: ok or Status::InvalidOperation error.
    */
   Status AddVertex(

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -145,6 +145,15 @@ class VerticesBuilder {
   }
 
   /**
+   * @brief Clear the vertices in this VerciesBuilder.
+   */
+  inline void Clear() {
+    vertices_.clear();
+    num_vertices_ = 0;
+    is_saved_ = false;
+  }
+
+  /**
    * @brief Set the validate level.
    *
    * @param validate_level The validate level to set.
@@ -161,7 +170,7 @@ class VerticesBuilder {
   inline ValidateLevel GetValidateLevel() const { return validate_level_; }
 
   /**
-   * @brief Check if adding a vertex with the given index is allowed.
+   * @brief Add a vertex with the given index.
    *
    * @param v The vertex to add.
    * @param index The given index, -1 means the next unused index.
@@ -169,20 +178,9 @@ class VerticesBuilder {
    * which is the writer's validate level by default.
    * @return Status: ok or Status::InvalidOperation error.
    */
-  Status Validate(
-      const Vertex& v, IdType index = -1,
-      ValidateLevel validate_level = ValidateLevel::default_validate) const;
-
-  /**
-   * @brief Add a vertex with the given index.
-   *
-   * @param v The vertex to add.
-   * @param index The given index, -1 means the next unused index.
-   * @return Status: ok or Status::InvalidOperation error.
-   */
-  Status AddVertex(Vertex& v, IdType index = -1) {  // NOLINT
+  Status AddVertex(Vertex& v, IdType index = -1, ValidateLevel validate_level = ValidateLevel::default_validate) {  // NOLINT
     // validate
-    GAR_RETURN_NOT_OK(Validate(v, index));
+    GAR_RETURN_NOT_OK(validate(v, index, validate_level));
     // add a vertex
     if (index == -1) {
       v.SetId(vertices_.size());
@@ -226,6 +224,16 @@ class VerticesBuilder {
   }
 
  private:
+   /**
+   * @brief Check if adding a vertex with the given index is allowed.
+   *
+   * @param v The vertex to add.
+   * @param index The given index, -1 means the next unused index.
+   * @param validate_level The validate level for this operation.
+   * @return Status: ok or Status::InvalidOperation error.
+   */
+  Status validate(const Vertex& v, IdType index, ValidateLevel validate_level) const;
+
   /**
    * @brief Construct an array for a given property.
    *

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -178,9 +178,9 @@ class VerticesBuilder {
    * which is the writer's validate level by default.
    * @return Status: ok or Status::InvalidOperation error.
    */
-  Status AddVertex(Vertex& v, IdType index = -1,
-                   ValidateLevel validate_level =
-                       ValidateLevel::default_validate) {  // NOLINT
+  Status AddVertex(
+      Vertex& v, IdType index = -1,  // NOLINT
+      ValidateLevel validate_level = ValidateLevel::default_validate) {
     // validate
     GAR_RETURN_NOT_OK(validate(v, index, validate_level));
     // add a vertex

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -129,7 +129,10 @@ class VerticesBuilder {
    * @param vertex_info The vertex info that describes the vertex type.
    * @param prefix The absolute prefix.
    * @param start_vertex_index The start index of the vertices collection.
-   * @param validate_level The validate level, with no validate by default.
+   * @param validate_level The global validate level for the writer, with no
+   * validate by default. It could be ValidateLevel::no_validate,
+   * ValidateLevel::weak_validate or ValidateLevel::strong_validate, but could
+   * not be ValidateLevel::default_validate.
    */
   explicit VerticesBuilder(
       const VertexInfo& vertex_info, const std::string& prefix,
@@ -139,6 +142,11 @@ class VerticesBuilder {
         prefix_(prefix),
         start_vertex_index_(start_vertex_index),
         validate_level_(validate_level) {
+    if (validate_level_ == ValidateLevel::default_validate) {
+      throw std::runtime_error(
+          "default_validate is not allowed to be set as the global validate "
+          "level for VerticesBuilder");
+    }
     vertices_.clear();
     num_vertices_ = 0;
     is_saved_ = false;
@@ -159,6 +167,9 @@ class VerticesBuilder {
    * @param validate_level The validate level to set.
    */
   inline void SetValidateLevel(const ValidateLevel& validate_level) {
+    if (validate_level == ValidateLevel::default_validate) {
+      return;
+    }
     validate_level_ = validate_level;
   }
 

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -100,9 +100,10 @@ Status VertexPropertyWriter::validate(const IdType& count,
   if (validate_level == ValidateLevel::no_validate)
     return Status::OK();
   // weak & strong validate
-  if (count < 0)
+  if (count < 0) {
     return Status::InvalidOperation(
         "the number of vertices must be non-negative");
+  }
   return Status::OK();
 }
 
@@ -117,9 +118,10 @@ Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
   if (validate_level == ValidateLevel::no_validate)
     return Status::OK();
   // weak & strong validate
-  if (!vertex_info_.ContainPropertyGroup(property_group))
+  if (!vertex_info_.ContainPropertyGroup(property_group)) {
     return Status::InvalidOperation(
         "the property group does not exist in the vertex info");
+  }
   if (chunk_index < 0)
     return Status::InvalidOperation("invalid vertex chunk index");
   return Status::OK();
@@ -138,18 +140,20 @@ Status VertexPropertyWriter::validate(
   // validate property_group & chunk_index
   GAR_RETURN_NOT_OK(validate(property_group, chunk_index, validate_level));
   // weak validate for the input_table
-  if (input_table->num_rows() > vertex_info_.GetChunkSize())
+  if (input_table->num_rows() > vertex_info_.GetChunkSize()) {
     return Status::OutOfRange(
         "the number of rows in the input table is larger than the vertex chunk "
         "size");
+  }
   // strong validate for the input_table
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();
     for (auto& property : property_group.GetProperties()) {
       int indice = schema->GetFieldIndex(property.name);
-      if (indice == -1)
+      if (indice == -1) {
         return Status::InvalidOperation("property: " + property.name +
                                         " not found");
+      }
       auto field = schema->field(indice);
       if (DataType::ArrowDataTypeToDataType(field->type()) != property.type) {
         std::string err_msg =
@@ -260,11 +264,12 @@ Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
   if (validate_level == ValidateLevel::no_validate)
     return Status::OK();
   // weak & strong validate for adj list type
-  if (!edge_info_.ContainAdjList(adj_list_type_))
+  if (!edge_info_.ContainAdjList(adj_list_type_)) {
     return Status::InvalidOperation(
         "the adj list type " +
         std::string(AdjListTypeToString(adj_list_type_)) +
         "  does not exist in the edge info");
+  }
   // weak & strong validate for count or index
   if (count_or_index1 < 0 || count_or_index2 < 0)
     return Status::InvalidOperation("the count or index must be non-negative");
@@ -283,9 +288,10 @@ Status EdgeChunkWriter::validate(const PropertyGroup& property_group,
   // validate for adj list type & index
   GAR_RETURN_NOT_OK(validate(vertex_chunk_index, chunk_index, validate_level));
   // weak & strong validate for property group
-  if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_))
+  if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_)) {
     return Status::InvalidOperation(
         "the property group does not exist in the edge info");
+  }
   return Status::OK();
 }
 
@@ -302,21 +308,24 @@ Status EdgeChunkWriter::validate(
   GAR_RETURN_NOT_OK(validate(vertex_chunk_index, 0, validate_level));
   // weak validate for the input table
   if (adj_list_type_ != AdjListType::ordered_by_source &&
-      adj_list_type_ != AdjListType::ordered_by_dest)
+      adj_list_type_ != AdjListType::ordered_by_dest) {
     return Status::InvalidOperation(
         "the adj list type has to be ordered_by_source or ordered_by_dest, but "
         "got " +
         std::string(AdjListTypeToString(adj_list_type_)));
+  }
   if (adj_list_type_ == AdjListType::ordered_by_source &&
-      input_table->num_rows() > edge_info_.GetSrcChunkSize() + 1)
+      input_table->num_rows() > edge_info_.GetSrcChunkSize() + 1) {
     return Status::OutOfRange(
         "the number of rows in the input table is larger than the offset table "
         "size for a vertex chunk");
+  }
   if (adj_list_type_ == AdjListType::ordered_by_dest &&
-      input_table->num_rows() > edge_info_.GetDstChunkSize() + 1)
+      input_table->num_rows() > edge_info_.GetDstChunkSize() + 1) {
     return Status::OutOfRange(
         "the number of rows in the input table is larger than the offset table "
         "size for a vertex chunk");
+  }
   // strong validate for the input_table
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();
@@ -324,10 +333,11 @@ Status EdgeChunkWriter::validate(
     if (index == -1)
       return Status::InvalidOperation("the offset column is not provided");
     auto field = schema->field(index);
-    if (field->type()->id() != arrow::Type::INT64)
+    if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
           "the data type for offset column should be INT64, but got " +
           field->type()->name());
+    }
   }
   return Status::OK();
 }
@@ -344,10 +354,11 @@ Status EdgeChunkWriter::validate(
   // validate for adj list type & index
   GAR_RETURN_NOT_OK(validate(vertex_chunk_index, chunk_index, validate_level));
   // weak validate for the input table
-  if (input_table->num_rows() > edge_info_.GetChunkSize())
+  if (input_table->num_rows() > edge_info_.GetChunkSize()) {
     return Status::OutOfRange(
         "the number of rows in the input table is larger than the edge chunk "
         "size");
+  }
   // stong validate for the input table
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();
@@ -355,18 +366,20 @@ Status EdgeChunkWriter::validate(
     if (index == -1)
       return Status::InvalidOperation("the source column is not provided");
     auto field = schema->field(index);
-    if (field->type()->id() != arrow::Type::INT64)
+    if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
           "the data type for source column should be INT64, but got " +
           field->type()->name());
+    }
     index = schema->GetFieldIndex(GeneralParams::kDstIndexCol);
     if (index == -1)
       return Status::InvalidOperation("the destination column is not provided");
     field = schema->field(index);
-    if (field->type()->id() != arrow::Type::INT64)
+    if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
           "the data type for destination  column should be INT64, but got " +
           field->type()->name());
+    }
   }
   return Status::OK();
 }

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -90,7 +90,9 @@ Result<std::shared_ptr<arrow::Table>> ExecutePlanAndCollectAsTable(
 
 // implementations for VertexPropertyChunkWriter
 
-Status VertexPropertyWriter::validate(const IdType& count, ValidateLevel validate_level) const noexcept {
+Status VertexPropertyWriter::validate(const IdType& count,
+                                      ValidateLevel validate_level) const
+    noexcept {
   // use the writer's validate level
   if (validate_level == ValidateLevel::default_validate)
     validate_level = validate_level_;
@@ -99,12 +101,15 @@ Status VertexPropertyWriter::validate(const IdType& count, ValidateLevel validat
     return Status::OK();
   // weak & strong validate
   if (count < 0)
-    return Status::InvalidOperation("the number of vertices must be non-negative");
+    return Status::InvalidOperation(
+        "the number of vertices must be non-negative");
   return Status::OK();
 }
 
-Status VertexPropertyWriter::validate(const PropertyGroup& property_group, IdType chunk_index,
-                ValidateLevel validate_level) const noexcept {
+Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
+                                      IdType chunk_index,
+                                      ValidateLevel validate_level) const
+    noexcept {
   // use the writer's validate level
   if (validate_level == ValidateLevel::default_validate)
     validate_level = validate_level_;
@@ -161,8 +166,8 @@ Status VertexPropertyWriter::validate(
   return Status::OK();
 }
 
-Status VertexPropertyWriter::WriteVerticesNum(const IdType& count, ValidateLevel validate_level) const
-    noexcept {
+Status VertexPropertyWriter::WriteVerticesNum(
+    const IdType& count, ValidateLevel validate_level) const noexcept {
   GAR_RETURN_NOT_OK(validate(count, validate_level));
   GAR_ASSIGN_OR_RAISE(auto suffix, vertex_info_.GetVerticesNumFilePath());
   std::string path = prefix_ + suffix;
@@ -171,8 +176,10 @@ Status VertexPropertyWriter::WriteVerticesNum(const IdType& count, ValidateLevel
 
 Status VertexPropertyWriter::WriteChunk(const std::string& file_name,
                                         const PropertyGroup& property_group,
-                                        IdType chunk_index, ValidateLevel validate_level) const noexcept {
-  GAR_RETURN_NOT_OK(validate(property_group, chunk_index, validate_level));                                  
+                                        IdType chunk_index,
+                                        ValidateLevel validate_level) const
+    noexcept {
+  GAR_RETURN_NOT_OK(validate(property_group, chunk_index, validate_level));
   GAR_ASSIGN_OR_RAISE(auto suffix,
                       vertex_info_.GetFilePath(property_group, chunk_index));
   std::string path = prefix_ + suffix;
@@ -181,8 +188,10 @@ Status VertexPropertyWriter::WriteChunk(const std::string& file_name,
 
 Status VertexPropertyWriter::WriteChunk(
     const std::shared_ptr<arrow::Table>& input_table,
-    const PropertyGroup& property_group, IdType chunk_index, ValidateLevel validate_level) const noexcept {
-  GAR_RETURN_NOT_OK(validate(input_table, property_group, chunk_index, validate_level));
+    const PropertyGroup& property_group, IdType chunk_index,
+    ValidateLevel validate_level) const noexcept {
+  GAR_RETURN_NOT_OK(
+      validate(input_table, property_group, chunk_index, validate_level));
   auto file_type = property_group.GetFileType();
 
   std::vector<int> indices;
@@ -206,42 +215,88 @@ Status VertexPropertyWriter::WriteChunk(
 }
 
 Status VertexPropertyWriter::WriteChunk(
-    const std::shared_ptr<arrow::Table>& input_table, IdType chunk_index, ValidateLevel validate_level) const
-    noexcept {
+    const std::shared_ptr<arrow::Table>& input_table, IdType chunk_index,
+    ValidateLevel validate_level) const noexcept {
   auto property_groups = vertex_info_.GetPropertyGroups();
   for (auto& property_group : property_groups) {
-    GAR_RETURN_NOT_OK(WriteChunk(input_table, property_group, chunk_index, validate_level));
+    GAR_RETURN_NOT_OK(
+        WriteChunk(input_table, property_group, chunk_index, validate_level));
   }
   return Status::OK();
 }
 
 Status VertexPropertyWriter::WriteTable(
     const std::shared_ptr<arrow::Table>& input_table,
-    const PropertyGroup& property_group, IdType start_chunk_index, ValidateLevel validate_level) const
-    noexcept {
+    const PropertyGroup& property_group, IdType start_chunk_index,
+    ValidateLevel validate_level) const noexcept {
   IdType chunk_size = vertex_info_.GetChunkSize();
   int64_t length = input_table->num_rows();
   IdType chunk_index = start_chunk_index;
   for (int64_t offset = 0; offset < length;
        offset += chunk_size, chunk_index++) {
     auto in_chunk = input_table->Slice(offset, chunk_size);
-    GAR_RETURN_NOT_OK(WriteChunk(in_chunk, property_group, chunk_index, validate_level));
+    GAR_RETURN_NOT_OK(
+        WriteChunk(in_chunk, property_group, chunk_index, validate_level));
   }
   return Status::OK();
 }
 
 Status VertexPropertyWriter::WriteTable(
-    const std::shared_ptr<arrow::Table>& input_table,
-    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
+    const std::shared_ptr<arrow::Table>& input_table, IdType start_chunk_index,
+    ValidateLevel validate_level) const noexcept {
   auto property_groups = vertex_info_.GetPropertyGroups();
   for (auto& property_group : property_groups) {
-    GAR_RETURN_NOT_OK(
-        WriteTable(input_table, property_group, start_chunk_index, validate_level));
+    GAR_RETURN_NOT_OK(WriteTable(input_table, property_group, start_chunk_index,
+                                 validate_level));
   }
   return Status::OK();
 }
 
 // implementations for EdgeChunkWriter
+
+Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
+                                 ValidateLevel validate_level) const noexcept {
+  // use the writer's validate level
+  if (validate_level == ValidateLevel::default_validate)
+    validate_level = validate_level_;
+  // no validate
+  if (validate_level == ValidateLevel::no_validate)
+    return Status::OK();
+  // weak & strong validate
+  if (count_or_index1 < 0 || count_or_index2 < 0)
+    return Status::InvalidOperation("the count or index must be non-negative");
+  if (!edge_info_.ContainAdjList(adj_list_type_))
+    return Status::InvalidOperation(
+        "the adj list type " +
+        std::string(AdjListTypeToString(adj_list_type_)) +
+        "  does not exist in the edge info");
+  return Status::OK();
+}
+
+Status EdgeChunkWriter::validate(const PropertyGroup& property_group,
+                                 IdType vertex_chunk_index, IdType chunk_index,
+                                 ValidateLevel validate_level) const noexcept {
+  // use the writer's validate level
+  if (validate_level == ValidateLevel::default_validate)
+    validate_level = validate_level_;
+  // no validate
+  if (validate_level == ValidateLevel::no_validate)
+    return Status::OK();
+  // weak & strong validate
+  if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_))
+    return Status::InvalidOperation(
+        "the property group does not exist in the edge info");
+  if (!edge_info_.ContainAdjList(adj_list_type_))
+    return Status::InvalidOperation(
+        "the adj list type " +
+        std::string(AdjListTypeToString(adj_list_type_)) +
+        "  does not exist in the edge info");
+  if (vertex_chunk_index < 0)
+    return Status::InvalidOperation("invalid vertex chunk index");
+  if (chunk_index < 0)
+    return Status::InvalidOperation("invalid edge chunk index");
+  return Status::OK();
+}
 
 Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
@@ -384,14 +439,20 @@ Status EdgeChunkWriter::validate(
 }
 
 Status EdgeChunkWriter::WriteEdgesNum(IdType vertex_chunk_index,
-                                      const IdType& count) const noexcept {
+                                      const IdType& count,
+                                      ValidateLevel validate_level) const
+    noexcept {
+  GAR_RETURN_NOT_OK(validate(vertex_chunk_index, count, validate_level));
   GAR_ASSIGN_OR_RAISE(auto suffix, edge_info_.GetEdgesNumFilePath(
                                        vertex_chunk_index, adj_list_type_));
   std::string path = prefix_ + suffix;
   return fs_->WriteValueToFile<IdType>(count, path);
 }
 
-Status EdgeChunkWriter::WriteVerticesNum(const IdType& count) const noexcept {
+Status EdgeChunkWriter::WriteVerticesNum(const IdType& count,
+                                         ValidateLevel validate_level) const
+    noexcept {
+  GAR_RETURN_NOT_OK(validate(0, count, validate_level));
   GAR_ASSIGN_OR_RAISE(auto suffix,
                       edge_info_.GetVerticesNumFilePath(adj_list_type_));
   std::string path = prefix_ + suffix;
@@ -399,8 +460,10 @@ Status EdgeChunkWriter::WriteVerticesNum(const IdType& count) const noexcept {
 }
 
 Status EdgeChunkWriter::WriteOffsetChunk(const std::string& file_name,
-                                         IdType vertex_chunk_index) const
+                                         IdType vertex_chunk_index,
+                                         ValidateLevel validate_level) const
     noexcept {
+  GAR_RETURN_NOT_OK(validate(vertex_chunk_index, 0, validate_level));
   GAR_ASSIGN_OR_RAISE(auto suffix, edge_info_.GetAdjListOffsetFilePath(
                                        vertex_chunk_index, adj_list_type_));
   std::string path = prefix_ + suffix;
@@ -409,7 +472,10 @@ Status EdgeChunkWriter::WriteOffsetChunk(const std::string& file_name,
 
 Status EdgeChunkWriter::WriteAdjListChunk(const std::string& file_name,
                                           IdType vertex_chunk_index,
-                                          IdType chunk_index) const noexcept {
+                                          IdType chunk_index,
+                                          ValidateLevel validate_level) const
+    noexcept {
+  GAR_RETURN_NOT_OK(validate(vertex_chunk_index, chunk_index, validate_level));
   GAR_ASSIGN_OR_RAISE(
       auto suffix, edge_info_.GetAdjListFilePath(vertex_chunk_index,
                                                  chunk_index, adj_list_type_));
@@ -420,7 +486,11 @@ Status EdgeChunkWriter::WriteAdjListChunk(const std::string& file_name,
 Status EdgeChunkWriter::WritePropertyChunk(const std::string& file_name,
                                            const PropertyGroup& property_group,
                                            IdType vertex_chunk_index,
-                                           IdType chunk_index) const noexcept {
+                                           IdType chunk_index,
+                                           ValidateLevel validate_level) const
+    noexcept {
+  GAR_RETURN_NOT_OK(validate(property_group, vertex_chunk_index, chunk_index,
+                             validate_level));
   GAR_ASSIGN_OR_RAISE(auto suffix, edge_info_.GetPropertyFilePath(
                                        property_group, adj_list_type_,
                                        vertex_chunk_index, chunk_index));
@@ -429,9 +499,9 @@ Status EdgeChunkWriter::WritePropertyChunk(const std::string& file_name,
 }
 
 Status EdgeChunkWriter::WriteOffsetChunk(
-    const std::shared_ptr<arrow::Table>& input_table,
-    IdType vertex_chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(validate(input_table, vertex_chunk_index));
+    const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
+    ValidateLevel validate_level) const noexcept {
+  GAR_RETURN_NOT_OK(validate(input_table, vertex_chunk_index, validate_level));
   GAR_ASSIGN_OR_RAISE(auto file_type, edge_info_.GetFileType(adj_list_type_));
   auto schema = input_table->schema();
   int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
@@ -446,8 +516,9 @@ Status EdgeChunkWriter::WriteOffsetChunk(
 
 Status EdgeChunkWriter::WriteAdjListChunk(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(validate(input_table, vertex_chunk_index, chunk_index));
+    IdType chunk_index, ValidateLevel validate_level) const noexcept {
+  GAR_RETURN_NOT_OK(
+      validate(input_table, vertex_chunk_index, chunk_index, validate_level));
   GAR_ASSIGN_OR_RAISE(auto file_type, edge_info_.GetFileType(adj_list_type_));
   std::vector<int> indices;
   indices.clear();
@@ -472,9 +543,9 @@ Status EdgeChunkWriter::WriteAdjListChunk(
 Status EdgeChunkWriter::WritePropertyChunk(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType vertex_chunk_index,
-    IdType chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(
-      validate(input_table, property_group, vertex_chunk_index, chunk_index));
+    IdType chunk_index, ValidateLevel validate_level) const noexcept {
+  GAR_RETURN_NOT_OK(validate(input_table, property_group, vertex_chunk_index,
+                             chunk_index, validate_level));
   auto file_type = property_group.GetFileType();
 
   std::vector<int> indices;
@@ -499,34 +570,36 @@ Status EdgeChunkWriter::WritePropertyChunk(
 
 Status EdgeChunkWriter::WritePropertyChunk(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType chunk_index) const noexcept {
+    IdType chunk_index, ValidateLevel validate_level) const noexcept {
   GAR_ASSIGN_OR_RAISE(auto& property_groups,
                       edge_info_.GetPropertyGroups(adj_list_type_));
   for (auto& property_group : property_groups) {
     GAR_RETURN_NOT_OK(WritePropertyChunk(input_table, property_group,
-                                         vertex_chunk_index, chunk_index));
+                                         vertex_chunk_index, chunk_index,
+                                         validate_level));
   }
   return Status::OK();
 }
 
 Status EdgeChunkWriter::WriteChunk(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(
-      WriteAdjListChunk(input_table, vertex_chunk_index, chunk_index));
-  return WritePropertyChunk(input_table, vertex_chunk_index, chunk_index);
+    IdType chunk_index, ValidateLevel validate_level) const noexcept {
+  GAR_RETURN_NOT_OK(WriteAdjListChunk(input_table, vertex_chunk_index,
+                                      chunk_index, validate_level));
+  return WritePropertyChunk(input_table, vertex_chunk_index, chunk_index,
+                            validate_level);
 }
 
 Status EdgeChunkWriter::WriteAdjListTable(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   int64_t length = input_table->num_rows();
   IdType chunk_index = start_chunk_index;
   for (int64_t offset = 0; offset < length;
        offset += chunk_size_, chunk_index++) {
     auto in_chunk = input_table->Slice(offset, chunk_size_);
-    GAR_RETURN_NOT_OK(
-        WriteAdjListChunk(in_chunk, vertex_chunk_index, chunk_index));
+    GAR_RETURN_NOT_OK(WriteAdjListChunk(in_chunk, vertex_chunk_index,
+                                        chunk_index, validate_level));
   }
   return Status::OK();
 }
@@ -534,48 +607,50 @@ Status EdgeChunkWriter::WriteAdjListTable(
 Status EdgeChunkWriter::WritePropertyTable(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   int64_t length = input_table->num_rows();
   IdType chunk_index = start_chunk_index;
   for (int64_t offset = 0; offset < length;
        offset += chunk_size_, chunk_index++) {
     auto in_chunk = input_table->Slice(offset, chunk_size_);
     GAR_RETURN_NOT_OK(WritePropertyChunk(in_chunk, property_group,
-                                         vertex_chunk_index, chunk_index));
+                                         vertex_chunk_index, chunk_index,
+                                         validate_level));
   }
   return Status::OK();
 }
 
 Status EdgeChunkWriter::WritePropertyTable(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   int64_t length = input_table->num_rows();
   IdType chunk_index = start_chunk_index;
   for (int64_t offset = 0; offset < length;
        offset += chunk_size_, chunk_index++) {
     auto in_chunk = input_table->Slice(offset, chunk_size_);
-    GAR_RETURN_NOT_OK(
-        WritePropertyChunk(in_chunk, vertex_chunk_index, chunk_index));
+    GAR_RETURN_NOT_OK(WritePropertyChunk(in_chunk, vertex_chunk_index,
+                                         chunk_index, validate_level));
   }
   return Status::OK();
 }
 
 Status EdgeChunkWriter::WriteTable(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   int64_t length = input_table->num_rows();
   IdType chunk_index = start_chunk_index;
   for (int64_t offset = 0; offset < length;
        offset += chunk_size_, chunk_index++) {
     auto in_chunk = input_table->Slice(offset, chunk_size_);
-    GAR_RETURN_NOT_OK(WriteChunk(in_chunk, vertex_chunk_index, chunk_index));
+    GAR_RETURN_NOT_OK(
+        WriteChunk(in_chunk, vertex_chunk_index, chunk_index, validate_level));
   }
   return Status::OK();
 }
 
 Status EdgeChunkWriter::SortAndWriteAdjListTable(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   GAR_ASSIGN_OR_RAISE(
       auto response_table,
       sortTable(input_table, getSortColumnName(adj_list_type_)));
@@ -585,36 +660,37 @@ Status EdgeChunkWriter::SortAndWriteAdjListTable(
         auto offset_table,
         getOffsetTable(response_table, getSortColumnName(adj_list_type_),
                        vertex_chunk_index));
-    GAR_RETURN_NOT_OK(WriteOffsetChunk(offset_table, vertex_chunk_index));
+    GAR_RETURN_NOT_OK(
+        WriteOffsetChunk(offset_table, vertex_chunk_index, validate_level));
   }
   return WriteAdjListTable(response_table, vertex_chunk_index,
-                           start_chunk_index);
+                           start_chunk_index, validate_level);
 }
 
 Status EdgeChunkWriter::SortAndWritePropertyTable(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   GAR_ASSIGN_OR_RAISE(
       auto response_table,
       sortTable(input_table, getSortColumnName(adj_list_type_)));
   return WritePropertyTable(response_table, property_group, vertex_chunk_index,
-                            start_chunk_index);
+                            start_chunk_index, validate_level);
 }
 
 Status EdgeChunkWriter::SortAndWritePropertyTable(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   GAR_ASSIGN_OR_RAISE(
       auto response_table,
       sortTable(input_table, getSortColumnName(adj_list_type_)));
   return WritePropertyTable(response_table, vertex_chunk_index,
-                            start_chunk_index);
+                            start_chunk_index, validate_level);
 }
 
 Status EdgeChunkWriter::SortAndWriteTable(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
-    IdType start_chunk_index) const noexcept {
+    IdType start_chunk_index, ValidateLevel validate_level) const noexcept {
   GAR_ASSIGN_OR_RAISE(
       auto response_table,
       sortTable(input_table, getSortColumnName(adj_list_type_)));
@@ -625,10 +701,12 @@ Status EdgeChunkWriter::SortAndWriteTable(
         auto offset_table,
         getOffsetTable(response_table, getSortColumnName(adj_list_type_),
                        vertex_chunk_index));
-    GAR_RETURN_NOT_OK(WriteOffsetChunk(offset_table, vertex_chunk_index));
+    GAR_RETURN_NOT_OK(
+        WriteOffsetChunk(offset_table, vertex_chunk_index, validate_level));
   }
 
-  return WriteTable(response_table, vertex_chunk_index, start_chunk_index);
+  return WriteTable(response_table, vertex_chunk_index, start_chunk_index,
+                    validate_level);
 }
 
 Result<std::shared_ptr<arrow::Table>> EdgeChunkWriter::getOffsetTable(

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -90,7 +90,7 @@ Result<std::shared_ptr<arrow::Table>> ExecutePlanAndCollectAsTable(
 
 // implementations for VertexPropertyChunkWriter
 
-Status VertexPropertyWriter::Validate(
+Status VertexPropertyWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType chunk_index,
     ValidateLevel validate_level) const noexcept {
@@ -150,7 +150,7 @@ Status VertexPropertyWriter::WriteChunk(const std::string& file_name,
 Status VertexPropertyWriter::WriteChunk(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(Validate(input_table, property_group, chunk_index));
+  GAR_RETURN_NOT_OK(validate(input_table, property_group, chunk_index));
   auto file_type = property_group.GetFileType();
 
   std::vector<int> indices;
@@ -211,7 +211,7 @@ Status VertexPropertyWriter::WriteTable(
 
 // implementations for EdgeChunkWriter
 
-Status EdgeChunkWriter::Validate(
+Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
     ValidateLevel validate_level) const noexcept {
   // use the writer's validate level
@@ -259,7 +259,7 @@ Status EdgeChunkWriter::Validate(
   return Status::OK();
 }
 
-Status EdgeChunkWriter::Validate(
+Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
     IdType chunk_index, ValidateLevel validate_level) const noexcept {
   // use the writer's validate level
@@ -305,7 +305,7 @@ Status EdgeChunkWriter::Validate(
   return Status::OK();
 }
 
-Status EdgeChunkWriter::Validate(
+Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType vertex_chunk_index,
     IdType chunk_index, ValidateLevel validate_level) const noexcept {
@@ -399,7 +399,7 @@ Status EdgeChunkWriter::WritePropertyChunk(const std::string& file_name,
 Status EdgeChunkWriter::WriteOffsetChunk(
     const std::shared_ptr<arrow::Table>& input_table,
     IdType vertex_chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(Validate(input_table, vertex_chunk_index));
+  GAR_RETURN_NOT_OK(validate(input_table, vertex_chunk_index));
   GAR_ASSIGN_OR_RAISE(auto file_type, edge_info_.GetFileType(adj_list_type_));
   auto schema = input_table->schema();
   int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
@@ -415,7 +415,7 @@ Status EdgeChunkWriter::WriteOffsetChunk(
 Status EdgeChunkWriter::WriteAdjListChunk(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
     IdType chunk_index) const noexcept {
-  GAR_RETURN_NOT_OK(Validate(input_table, vertex_chunk_index, chunk_index));
+  GAR_RETURN_NOT_OK(validate(input_table, vertex_chunk_index, chunk_index));
   GAR_ASSIGN_OR_RAISE(auto file_type, edge_info_.GetFileType(adj_list_type_));
   std::vector<int> indices;
   indices.clear();
@@ -442,7 +442,7 @@ Status EdgeChunkWriter::WritePropertyChunk(
     const PropertyGroup& property_group, IdType vertex_chunk_index,
     IdType chunk_index) const noexcept {
   GAR_RETURN_NOT_OK(
-      Validate(input_table, property_group, vertex_chunk_index, chunk_index));
+      validate(input_table, property_group, vertex_chunk_index, chunk_index));
   auto file_type = property_group.GetFileType();
 
   std::vector<int> indices;

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -90,6 +90,7 @@ Result<std::shared_ptr<arrow::Table>> ExecutePlanAndCollectAsTable(
 
 // implementations for VertexPropertyChunkWriter
 
+// Check if the opeartion of writing vertices number is allowed.
 Status VertexPropertyWriter::validate(const IdType& count,
                                       ValidateLevel validate_level) const
     noexcept {
@@ -107,6 +108,7 @@ Status VertexPropertyWriter::validate(const IdType& count,
   return Status::OK();
 }
 
+// Check if the opeartion of copying a file as a chunk is allowed.
 Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
                                       IdType chunk_index,
                                       ValidateLevel validate_level) const
@@ -127,6 +129,7 @@ Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
   return Status::OK();
 }
 
+// Check if the opeartion of writing a table as a chunk is allowed.
 Status VertexPropertyWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType chunk_index,
@@ -255,6 +258,7 @@ Status VertexPropertyWriter::WriteTable(
 
 // implementations for EdgeChunkWriter
 
+// Check if the operation of writing number or copying a file is allowed.
 Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
                                  ValidateLevel validate_level) const noexcept {
   // use the writer's validate level
@@ -276,6 +280,7 @@ Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
   return Status::OK();
 }
 
+// Check if the operation of copying a file as a property chunk is allowed.
 Status EdgeChunkWriter::validate(const PropertyGroup& property_group,
                                  IdType vertex_chunk_index, IdType chunk_index,
                                  ValidateLevel validate_level) const noexcept {
@@ -295,6 +300,7 @@ Status EdgeChunkWriter::validate(const PropertyGroup& property_group,
   return Status::OK();
 }
 
+// Check if the operation of writing a table as an offset chunk is allowed.
 Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
     ValidateLevel validate_level) const noexcept {
@@ -342,6 +348,7 @@ Status EdgeChunkWriter::validate(
   return Status::OK();
 }
 
+// Check if the operation of writing a table as an adj list chunk is allowed.
 Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
     IdType chunk_index, ValidateLevel validate_level) const noexcept {
@@ -384,6 +391,7 @@ Status EdgeChunkWriter::validate(
   return Status::OK();
 }
 
+// Check if the operation of writing a table as a property chunk is allowed.
 Status EdgeChunkWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType vertex_chunk_index,

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -384,7 +384,7 @@ Status EdgeChunkWriter::validate(
     field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
-          "the data type for destination  column should be INT64, but got " +
+          "the data type for destination column should be INT64, but got " +
           field->type()->name());
     }
   }

--- a/cpp/src/edges_builder.cc
+++ b/cpp/src/edges_builder.cc
@@ -46,10 +46,11 @@ Status EdgesBuilder::validate(const Edge& e,
   if (validate_level == ValidateLevel::strong_validate) {
     for (auto& property : e.GetProperties()) {
       // check if the property is contained
-      if (!edge_info_.ContainProperty(property.first))
+      if (!edge_info_.ContainProperty(property.first)) {
         return Status::InvalidOperation(
             "invalid property name: " + property.first +
             ", which is not contained in the vertex info");
+      }
       // check if the property type is correct
       auto type = edge_info_.GetPropertyType(property.first).value();
       bool invalid_type = false;
@@ -223,10 +224,11 @@ Result<std::shared_ptr<arrow::Table>> EdgesBuilder::getOffsetTable(
       int64_t x = (adj_list_type_ == AdjListType::ordered_by_source
                        ? edges[index].GetSource()
                        : edges[index].GetDestination());
-      if (x <= i)
+      if (x <= i) {
         index++;
-      else
+      } else {
         break;
+      }
     }
     RETURN_NOT_ARROW_OK(builder.Append(index));
   }

--- a/cpp/src/edges_builder.cc
+++ b/cpp/src/edges_builder.cc
@@ -20,7 +20,7 @@ limitations under the License.
 namespace GAR_NAMESPACE_INTERNAL {
 namespace builder {
 
-Status EdgesBuilder::Validate(const Edge& e,
+Status EdgesBuilder::validate(const Edge& e,
                               ValidateLevel validate_level) const {
   // use the builder's validate level
   if (validate_level == ValidateLevel::default_validate)

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -19,7 +19,7 @@ limitations under the License.
 namespace GAR_NAMESPACE_INTERNAL {
 namespace builder {
 
-Status VerticesBuilder::Validate(const Vertex& v, IdType index,
+Status VerticesBuilder::validate(const Vertex& v, IdType index,
                                  ValidateLevel validate_level) const {
   // use the builder's validate level
   if (validate_level == ValidateLevel::default_validate)

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -40,18 +40,20 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
         "with the chunk size");
   }
   // the vertex index must larger than start index
-  if (index != -1 && index < start_vertex_index_)
+  if (index != -1 && index < start_vertex_index_) {
     return Status::InvalidOperation(
         "the vertex index must be larger than start index");
+  }
 
   // strong validate
   if (validate_level == ValidateLevel::strong_validate) {
     for (auto& property : v.GetProperties()) {
       // check if the property is contained
-      if (!vertex_info_.ContainProperty(property.first))
+      if (!vertex_info_.ContainProperty(property.first)) {
         return Status::InvalidOperation(
             "invalid property name: " + property.first +
             ", which is not contained in the vertex info");
+      }
       // check if the property type is correct
       auto type = vertex_info_.GetPropertyType(property.first).value();
       bool invalid_type = false;

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -220,6 +220,10 @@ TEST_CASE("test_edge_chunk_writer") {
   // Validate operation
   REQUIRE(writer.SortAndWriteAdjListTable(table, 0, 0).ok());
 
+  // Invalid count or index
+  REQUIRE(writer.WriteEdgesNum(-1, 0).IsInvalidOperation());
+  REQUIRE(writer.WriteEdgesNum(0, -1).IsInvalidOperation());
+  REQUIRE(writer.WriteVerticesNum(-1).IsInvalidOperation());
   // Out of range
   REQUIRE(writer.WriteOffsetChunk(table, 0).IsOutOfRange());
   // Invalid chunk id

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -86,6 +86,8 @@ TEST_CASE("test_vertex_property_writer_from_file") {
   // Validate operation
   REQUIRE(writer.WriteTable(table, 0).ok());
 
+  // Invalid vertices number
+  REQUIRE(writer.WriteVerticesNum(-1).IsInvalidOperation());
   // Out of range
   REQUIRE(writer.WriteChunk(table, 0).IsOutOfRange());
   // Invalid chunk id

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -62,15 +62,19 @@ TEST_CASE("test_vertices_builder") {
   GAR_NAMESPACE::builder::Vertex v;
   v.AddProperty("id", "id_of_string");
   REQUIRE(
-      builder.Validate(v, 0, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
+      builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
   REQUIRE(
-      builder.Validate(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
-  REQUIRE(builder.Validate(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate)
+      builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
+  REQUIRE(builder.AddVertex(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate)
               .IsInvalidOperation());
-  REQUIRE(builder.Validate(v, 0, GAR_NAMESPACE::ValidateLevel::strong_validate)
+  REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   v.AddProperty("invalid_name", "invalid_value");
-  REQUIRE(builder.Validate(v, 0).IsInvalidOperation());
+  REQUIRE(builder.AddVertex(v, 0).IsInvalidOperation());
+
+  // clear vertices
+  builder.Clear();
+  REQUIRE(builder.GetNum() == 0);
 
   // add vertices
   std::ifstream fp(root + "/ldbc_sample/person_0_0.csv");
@@ -84,7 +88,10 @@ TEST_CASE("test_vertices_builder") {
     getline(readstr, name, '|');
     names.push_back(name);
   }
+
+  int lines = 0;
   while (getline(fp, line)) {
+    lines++;
     std::string val;
     std::istringstream readstr(line);
     GAR_NAMESPACE::builder::Vertex v;
@@ -101,6 +108,9 @@ TEST_CASE("test_vertices_builder") {
     }
     REQUIRE(builder.AddVertex(v).ok());
   }
+
+  // check the number of vertices
+  REQUIRE(builder.GetNum() == lines);
 
   // dump
   REQUIRE(builder.Dump().ok());
@@ -140,13 +150,17 @@ TEST_CASE("test_edges_builder") {
   // check different validate levels
   GAR_NAMESPACE::builder::Edge e(0, 1);
   e.AddProperty("creationDate", 2020);
-  REQUIRE(builder.Validate(e, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
+  REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
   REQUIRE(
-      builder.Validate(e, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
-  REQUIRE(builder.Validate(e, GAR_NAMESPACE::ValidateLevel::strong_validate)
+      builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
+  REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   e.AddProperty("invalid_name", "invalid_value");
-  REQUIRE(builder.Validate(e).IsInvalidOperation());
+  REQUIRE(builder.AddEdge(e).IsInvalidOperation());
+
+  // clear edges
+  builder.Clear();
+  REQUIRE(builder.GetNum() == 0);
 
   // add edges
   std::ifstream fp(root + "/ldbc_sample/person_knows_person_0_0.csv");
@@ -155,8 +169,10 @@ TEST_CASE("test_edges_builder") {
   std::vector<std::string> names;
   std::istringstream readstr(line);
   std::map<std::string, int64_t> mapping;
-  int64_t cnt = 0;
+  int64_t cnt = 0, lines = 0;
+  
   while (getline(fp, line)) {
+    lines++;
     std::string val;
     std::istringstream readstr(line);
     int64_t s, d;
@@ -177,6 +193,9 @@ TEST_CASE("test_edges_builder") {
       }
     }
   }
+
+  // check the number of edges
+  REQUIRE(builder.GetNum() == lines);
 
   // dump
   REQUIRE(builder.Dump().ok());

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -63,8 +63,8 @@ TEST_CASE("test_vertices_builder") {
   v.AddProperty("id", "id_of_string");
   REQUIRE(
       builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
-  REQUIRE(
-      builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
+  REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate)
+              .ok());
   REQUIRE(builder.AddVertex(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate)
               .IsInvalidOperation());
   REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::strong_validate)
@@ -151,8 +151,7 @@ TEST_CASE("test_edges_builder") {
   GAR_NAMESPACE::builder::Edge e(0, 1);
   e.AddProperty("creationDate", 2020);
   REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
-  REQUIRE(
-      builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
+  REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::weak_validate).ok());
   REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   e.AddProperty("invalid_name", "invalid_value");
@@ -170,7 +169,7 @@ TEST_CASE("test_edges_builder") {
   std::istringstream readstr(line);
   std::map<std::string, int64_t> mapping;
   int64_t cnt = 0, lines = 0;
-  
+
   while (getline(fp, line)) {
     lines++;
     std::string val;

--- a/docs/reference/api-reference-cpp.rst
+++ b/docs/reference/api-reference-cpp.rst
@@ -181,6 +181,10 @@ Adj List Type
 ~~~~~~~~~~~~~~~~~~~
 .. doxygenenum:: GraphArchive::AdjListType
 
+Validate Level
+~~~~~~~~~~~~~~~~~~~
+.. doxygenenum:: GraphArchive::ValidateLevel
+
 
 Utilities
 ---------


### PR DESCRIPTION
## Proposed changes

We need to develop a more comprehensive and consistent approach to validation across all of GraphAr's tools and libraries. As the first step, this change redesigned and unified the implementation of validation for `Writer` and `Builder` in the C++ library.

- clarify and define different validation levels in the utils
- hide the `Validate` interface to users and use `validate_level` as a parameter of the writing operations
- simplify and unify the implementation for validation in `Writer` and `Builder`
- add a `Clear()` method to high-level `Builder`, enabling to add data and then dump for multiple rounds
- add test to prove the interface changes
- update C++ API Reference to include the `ValidateLevel` type

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Solve #183 

