### PR TITLE
[Improvement][C++] Refine the error message of errors of C++ SDK

### DIFF
--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -423,7 +423,7 @@ class EdgeIter {
       st = adj_list_reader_.next_chunk();
       ++global_chunk_index_;
       ++vertex_chunk_index_;
-      if (!st.IsOutOfRange()) {
+      if (!st.IsIndexError()) {
         GAR_ASSIGN_OR_RAISE_ERROR(num_row_of_chunk_,
                                   adj_list_reader_.GetRowNumOfChunk());
         for (auto& reader : property_readers_) {

--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -67,13 +67,15 @@ class Vertex {
   template <typename T>
   inline Result<T> property(const std::string& property) noexcept {
     if (properties_.find(property) == properties_.end()) {
-      return Status::KeyError("The property is not exist.");
+      return Status::KeyError("Property with name ", property,
+                              " does not exist in the vertex.");
     }
     try {
       T ret = std::any_cast<T>(properties_[property]);
       return ret;
     } catch (const std::bad_any_cast& e) {
-      return Status::TypeError("The property type is not match.");
+      return Status::TypeError("Any cast failed, the property type of ",
+                               property, " is not matched ", e.what());
     }
   }
 
@@ -120,13 +122,15 @@ class Edge {
   template <typename T>
   inline Result<T> property(const std::string& property) noexcept {
     if (properties_.find(property) == properties_.end()) {
-      return Status::KeyError("The property is not exist.");
+      return Status::KeyError("Property with name ", property,
+                              " does not exist in the edge.");
     }
     try {
       T ret = std::any_cast<T>(properties_[property]);
       return ret;
     } catch (const std::bad_any_cast& e) {
-      return Status::TypeError("The property type is not match.");
+      return Status::TypeError("Any cast failed, the property type of ",
+                               property, " is not matched ", e.what());
     }
   }
 
@@ -188,7 +192,8 @@ class VertexIter {
       GAR_ASSIGN_OR_RAISE(auto data, util::GetArrowArrayData(array));
       return util::ValueGetter<T>::Value(data, 0);
     }
-    return Status::KeyError("The property is not exist.");
+    return Status::KeyError("Property with name ", property,
+                            " does not exist in the vertex.");
   }
 
   /** The prefix increment operator. */
@@ -386,7 +391,8 @@ class EdgeIter {
       GAR_ASSIGN_OR_RAISE(auto data, util::GetArrowArrayData(array));
       return util::ValueGetter<T>::Value(data, 0);
     }
-    return Status::KeyError("The property is not exist.");
+    return Status::KeyError("Property with name ", property,
+                            " does not exist in the edge.");
   }
 
   /** The prefix increment operator. */
@@ -403,7 +409,8 @@ class EdgeIter {
       if (row_offset >= num_row_of_chunk_) {
         cur_offset_ = (cur_offset_ / chunk_size_ + 1) * chunk_size_;
         adj_list_reader_.seek(cur_offset_);
-        st = Status::KeyError();
+        st =
+            Status::KeyError("The row offset is overflow, move to next chunk.");
       }
     }
     if (st.ok() && num_row_of_chunk_ == chunk_size_ &&
@@ -1220,7 +1227,9 @@ static inline Result<Edges> ConstructEdgesCollection(
   GAR_ASSIGN_OR_RAISE(edge_info,
                       graph_info.GetEdgeInfo(src_label, edge_label, dst_label));
   if (!edge_info.ContainAdjList(adj_list_type)) {
-    return Status::Invalid("Invalid adj list type");
+    return Status::Invalid("The edge ", edge_label, " of adj list type ",
+                           AdjListTypeToString(adj_list_type),
+                           " doesn't exist.");
   }
   switch (adj_list_type) {
   case AdjListType::ordered_by_source:
@@ -1240,9 +1249,9 @@ static inline Result<Edges> ConstructEdgesCollection(
         edge_info, graph_info.GetPrefix(), vertex_chunk_begin,
         vertex_chunk_end);
   default:
-    return Status::Invalid("Invalid adj list type");
+    return Status::Invalid("Unknown adj list type.");
   }
-  return Status::Invalid("Invalid adj list type");
+  return Status::OK();
 }
 }  // namespace GAR_NAMESPACE_INTERNAL
 

--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -583,8 +583,9 @@ class EdgeInfo {
   Status AddPropertyGroup(const PropertyGroup& property_group,
                           AdjListType adj_list_type) noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::Invalid("Invalid adjacency list type: ",
-                             AdjListTypeToString(adj_list_type));
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in ", edge_label_, " edgeinfo.");
     }
     if (ContainPropertyGroup(property_group, adj_list_type)) {
       return Status::KeyError("Property group: ", property_group,
@@ -882,7 +883,7 @@ class EdgeInfo {
       IdType vertex_chunk_index, IdType edge_chunk_index) const {
     if (!ContainPropertyGroup(property_group, adj_list_type)) {
       return Status::KeyError("The property group: ", property_group,
-                              " is not found in the edge info");
+                              " is not found in the edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) +
            property_group.GetPrefix() + "part" +

--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -133,6 +133,17 @@ class PropertyGroup {
    */
   inline const std::string& GetPrefix() const { return prefix_; }
 
+  friend std::ostream& operator<<(std::ostream& stream,
+                                  const PropertyGroup& pg) {
+    for (size_t i = 0; i < pg.properties_.size(); ++i) {
+      stream << pg.properties_[i].name;
+      if (i != pg.properties_.size() - 1) {
+        stream << "_";
+      }
+    }
+    return stream;
+  }
+
  private:
   std::vector<Property> properties_;
   FileType file_type_;
@@ -209,22 +220,22 @@ class VertexInfo {
    */
   inline Status AddPropertyGroup(const PropertyGroup& property_group) {
     if (ContainPropertyGroup(property_group)) {
-      return Status::InvalidOperation(
-          "The property group has already existed, can't not be added again.");
+      return Status::Invalid("The property group ", property_group,
+                             " has already existed, can't not be added again.");
     }
     for (const auto& property : property_group.GetProperties()) {
       if (ContainProperty(property.name)) {
-        std::string err_msg = "The property " + property.name +
-                              " has already existed in the vertex info.";
-        return Status::InvalidOperation(err_msg);
+        return Status::Invalid("The property ", property.name,
+                               " has already existed in the ", label_,
+                               " vertex info, can't not be added again.");
       }
     }
 
     property_groups_.push_back(property_group);
     for (const auto& p : property_group.GetProperties()) {
       if (!version_.CheckType(p.type.ToTypeName())) {
-        return Status::Invalid(
-            "The property type is not supported by the version.");
+        return Status::Invalid("The property type ", p.type.ToTypeName(),
+                               " is not supported by the version.");
       }
       p2type_[p.name] = p.type;
       p2primary_[p.name] = p.is_primary;
@@ -280,7 +291,8 @@ class VertexInfo {
   Result<const PropertyGroup&> GetPropertyGroup(
       const std::string& property_name) const noexcept {
     if (!ContainProperty(property_name)) {
-      return Status::KeyError("The property is not found.");
+      return Status::KeyError("No property with name ", property_name,
+                              " found in ", label_, " vertex.");
     }
     return property_groups_[p2group_index_.at(property_name)];
   }
@@ -295,7 +307,8 @@ class VertexInfo {
   inline Result<DataType> GetPropertyType(
       const std::string& property_name) const noexcept {
     if (p2type_.find(property_name) == p2type_.end()) {
-      return Status::KeyError("The property is not found.");
+      return Status::KeyError("No property with name ", property_name,
+                              " found in ", label_, " vertex.");
     }
     return p2type_.at(property_name);
   }
@@ -336,7 +349,8 @@ class VertexInfo {
   inline Result<bool> IsPrimaryKey(const std::string& property_name) const
       noexcept {
     if (p2primary_.find(property_name) == p2primary_.end()) {
-      return Status::KeyError("The property is not found.");
+      return Status::KeyError("No property with name ", property_name,
+                              " found in ", label_, " vertex.");
     }
     return p2primary_.at(property_name);
   }
@@ -383,8 +397,8 @@ class VertexInfo {
   inline Result<std::string> GetFilePath(const PropertyGroup& property_group,
                                          IdType chunk_index) const noexcept {
     if (!ContainPropertyGroup(property_group)) {
-      return Status::KeyError(
-          "Vertex info does not contain the property group.");
+      return Status::KeyError("The property group: ", property_group,
+                              " is not found in the ", label_, " vertex.");
     }
     return prefix_ + property_group.GetPrefix() + "chunk" +
            std::to_string(chunk_index);
@@ -400,8 +414,8 @@ class VertexInfo {
   inline Result<std::string> GetPathPrefix(
       const PropertyGroup& property_group) const noexcept {
     if (!ContainPropertyGroup(property_group)) {
-      return Status::KeyError(
-          "Vertex info does not contain the property group.");
+      return Status::KeyError("The property group: ", property_group,
+                              " is not found in the ", label_, " vertex.");
     }
     return prefix_ + property_group.GetPrefix();
   }
@@ -541,8 +555,9 @@ class EdgeInfo {
   Status AddAdjList(const AdjListType& adj_list_type, FileType file_type,
                     const std::string& prefix = "") {
     if (ContainAdjList(adj_list_type)) {
-      return Status::InvalidOperation(
-          "The adj list type has already existed in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " already exists in edge info.");
     }
     if (prefix.empty()) {
       // default prefix
@@ -568,18 +583,17 @@ class EdgeInfo {
   Status AddPropertyGroup(const PropertyGroup& property_group,
                           AdjListType adj_list_type) noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::InvalidOperation(
-          "The adj list type not supported by edge info.");
+      return Status::Invalid("Invalid adjacency list type: ",
+                             AdjListTypeToString(adj_list_type));
     }
     if (ContainPropertyGroup(property_group, adj_list_type)) {
-      return Status::InvalidOperation(
-          "The property group has already existed.");
+      return Status::KeyError("Property group: ", property_group,
+                              " already exists in adjacency list.");
     }
     adj_list2property_groups_[adj_list_type].push_back(property_group);
     for (auto& p : property_group.GetProperties()) {
       if (!version_.CheckType(p.type.ToTypeName())) {
-        return Status::Invalid(
-            "The property type is not supported by the version.");
+        return Status::Invalid("Invalid property type: ", p.type.ToTypeName());
       }
       p2type_[p.name] = p.type;
       p2primary_[p.name] = p.is_primary;
@@ -698,7 +712,9 @@ class EdgeInfo {
   inline Result<FileType> GetFileType(AdjListType adj_list_type) const
       noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return adj_list2file_type_.at(adj_list_type);
   }
@@ -714,7 +730,9 @@ class EdgeInfo {
   inline Result<const std::vector<PropertyGroup>&> GetPropertyGroups(
       AdjListType adj_list_type) const noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return adj_list2property_groups_.at(adj_list_type);
   }
@@ -731,12 +749,12 @@ class EdgeInfo {
    */
   inline Result<const PropertyGroup&> GetPropertyGroup(
       const std::string& property, AdjListType adj_list_type) const noexcept {
-    if (p2group_index_.find(property) == p2group_index_.end()) {
-      return Status::KeyError("The property is not found.");
-    }
-    if (p2group_index_.at(property).find(adj_list_type) ==
-        p2group_index_.at(property).end()) {
-      return Status::KeyError("The property is not contained in the adj list.");
+    if (p2group_index_.find(property) == p2group_index_.end() ||
+        p2group_index_.at(property).find(adj_list_type) ==
+            p2group_index_.at(property).end()) {
+      return Status::KeyError("No property with name: ", property,
+                              " is found in edge info for adj list type: ",
+                              AdjListTypeToString(adj_list_type));
     }
     return adj_list2property_groups_.at(
         adj_list_type)[p2group_index_.at(property).at(adj_list_type)];
@@ -752,7 +770,9 @@ class EdgeInfo {
   inline Result<std::string> GetVerticesNumFilePath(
       AdjListType adj_list_type) const noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) + "vertex_count";
   }
@@ -768,7 +788,9 @@ class EdgeInfo {
   inline Result<std::string> GetEdgesNumFilePath(
       IdType vertex_chunk_index, AdjListType adj_list_type) const noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) + "edge_count" +
            std::to_string(vertex_chunk_index);
@@ -785,7 +807,9 @@ class EdgeInfo {
                                                 AdjListType adj_list_type) const
       noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) + "adj_list/part" +
            std::to_string(vertex_chunk_index) + "/" + "chunk" +
@@ -802,7 +826,9 @@ class EdgeInfo {
   inline Result<std::string> GetAdjListPathPrefix(
       const AdjListType& adj_list_type) const noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) + "adj_list/";
   }
@@ -816,7 +842,9 @@ class EdgeInfo {
   inline Result<std::string> GetAdjListOffsetFilePath(
       IdType vertex_chunk_index, AdjListType adj_list_type) const noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) + "offset/chunk" +
            std::to_string(vertex_chunk_index);
@@ -832,7 +860,9 @@ class EdgeInfo {
   inline Result<std::string> GetOffsetPathPrefix(
       AdjListType adj_list_type) const noexcept {
     if (!ContainAdjList(adj_list_type)) {
-      return Status::KeyError("The adj list type is not found in edge info.");
+      return Status::KeyError(
+          "Adjacency list type: ", AdjListTypeToString(adj_list_type),
+          " is not found in edge info.");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) + "offset/";
   }
@@ -851,8 +881,8 @@ class EdgeInfo {
       const PropertyGroup& property_group, AdjListType adj_list_type,
       IdType vertex_chunk_index, IdType edge_chunk_index) const {
     if (!ContainPropertyGroup(property_group, adj_list_type)) {
-      return Status::KeyError(
-          "The edge info does not contain the property group.");
+      return Status::KeyError("The property group: ", property_group,
+                              " is not found in the edge info");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) +
            property_group.GetPrefix() + "part" +
@@ -872,8 +902,8 @@ class EdgeInfo {
       const PropertyGroup& property_group, AdjListType adj_list_type) const
       noexcept {
     if (!ContainPropertyGroup(property_group, adj_list_type)) {
-      return Status::KeyError(
-          "The edge info does not contain the property group.");
+      return Status::KeyError("The property group: ", property_group,
+                              " is not found in the edge info");
     }
     return prefix_ + adj_list2prefix_.at(adj_list_type) +
            property_group.GetPrefix();
@@ -888,7 +918,8 @@ class EdgeInfo {
    */
   Result<DataType> GetPropertyType(const std::string& property) const noexcept {
     if (p2type_.find(property) == p2type_.end()) {
-      return Status::KeyError("The property is not found.");
+      return Status::KeyError("No property with name ", property,
+                              " is not found in the edge info");
     }
     return p2type_.at(property);
   }
@@ -902,7 +933,8 @@ class EdgeInfo {
    */
   Result<bool> IsPrimaryKey(const std::string& property) const noexcept {
     if (p2primary_.find(property) == p2primary_.end()) {
-      return Status::KeyError("The property is not found.");
+      return Status::KeyError("No property with name ", property,
+                              " is not found in the edge info");
     }
     return p2primary_.at(property);
   }
@@ -1063,7 +1095,8 @@ class GraphInfo {
   Status AddVertex(const VertexInfo& vertex_info) noexcept {
     std::string label = vertex_info.GetLabel();
     if (vertex2info_.find(label) != vertex2info_.end()) {
-      return Status::InvalidOperation("The vertex info is already contained.");
+      return Status::Invalid("The vertex info of ", label,
+                             " is already existed.");
     }
     vertex2info_.emplace(label, vertex_info);
     return Status::OK();
@@ -1081,7 +1114,7 @@ class GraphInfo {
                       edge_info.GetEdgeLabel() + REGULAR_SEPERATOR +
                       edge_info.GetDstLabel();
     if (edge2info_.find(key) != edge2info_.end()) {
-      return Status::InvalidOperation("The edge info is already contained.");
+      return Status::Invalid("The edge info of ", key, " is already existed.");
     }
     edge2info_.emplace(key, edge_info);
     return Status::OK();
@@ -1133,7 +1166,8 @@ class GraphInfo {
   inline Result<const VertexInfo&> GetVertexInfo(const std::string& label) const
       noexcept {
     if (vertex2info_.find(label) == vertex2info_.end()) {
-      return Status::KeyError("The vertex info is not found in graph info.");
+      return Status::KeyError("The vertex info of ", label,
+                              "is not found in graph info.");
     }
     return vertex2info_.at(label);
   }
@@ -1154,7 +1188,8 @@ class GraphInfo {
     std::string key = src_label + REGULAR_SEPERATOR + edge_label +
                       REGULAR_SEPERATOR + dst_label;
     if (edge2info_.find(key) == edge2info_.end()) {
-      return Status::KeyError("The edge info is not found in graph info.");
+      return Status::KeyError("The edge info of ", key,
+                              " is not found in graph info.");
     }
     return edge2info_.at(key);
   }
@@ -1168,7 +1203,8 @@ class GraphInfo {
   inline Result<const PropertyGroup&> GetVertexPropertyGroup(
       const std::string& label, const std::string& property) const noexcept {
     if (vertex2info_.find(label) == vertex2info_.end()) {
-      return Status::KeyError("The vertex info is not found in graph info.");
+      return Status::KeyError("The vertex info of ", label,
+                              "is not found in graph info.");
     }
     return vertex2info_.at(label).GetPropertyGroup(property);
   }
@@ -1189,7 +1225,8 @@ class GraphInfo {
     std::string key = src_label + REGULAR_SEPERATOR + edge_label +
                       REGULAR_SEPERATOR + dst_label;
     if (edge2info_.find(key) == edge2info_.end()) {
-      return Status::KeyError("The edge info is not found in graph info.");
+      return Status::KeyError("The edge info of ", key,
+                              " is not found in graph info.");
     }
     return edge2info_.at(key).GetPropertyGroup(property, adj_list_type);
   }

--- a/cpp/include/gar/reader/arrow_chunk_reader.h
+++ b/cpp/include/gar/reader/arrow_chunk_reader.h
@@ -244,10 +244,8 @@ class AdjListArrowChunkReader {
    *         end of all vertex chunks.
    */
   Status next_chunk() {
-    Status st;
     ++chunk_index_;
     while (chunk_index_ >= chunk_num_) {
-      st = Status::EndOfChunk("End of the adj list chunk of vertex chunk.");
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
         return Status::IndexError("vertex chunk index ", vertex_chunk_index_,
@@ -262,7 +260,7 @@ class AdjListArrowChunkReader {
     }
     seek_offset_ = chunk_index_ * edge_info_.GetChunkSize();
     chunk_table_.reset();
-    return st;
+    return Status::OK();
   }
 
   /**
@@ -520,10 +518,8 @@ class AdjListPropertyArrowChunkReader {
    *         end of all vertex chunks.
    */
   Status next_chunk() {
-    Status st;
     ++chunk_index_;
     while (chunk_index_ >= chunk_num_) {
-      st = Status::EndOfChunk("End of the adj list chunk of vertex chunk.");
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
         return Status::IndexError(
@@ -541,7 +537,7 @@ class AdjListPropertyArrowChunkReader {
     }
     seek_offset_ = chunk_index_ * edge_info_.GetChunkSize();
     chunk_table_.reset();
-    return st;
+    return Status::OK();
   }
 
   /**

--- a/cpp/include/gar/reader/arrow_chunk_reader.h
+++ b/cpp/include/gar/reader/arrow_chunk_reader.h
@@ -494,7 +494,8 @@ class AdjListPropertyArrowChunkReader {
       chunk_table_.reset();
     }
     if (chunk_index_ >= chunk_num_) {
-      return Status::KeyError("The edge offset ", index, " is out of range [0,",
+      return Status::KeyError("The edge offset ", offset,
+                              " is out of range [0,",
                               edge_info_.GetChunkSize() * chunk_num_,
                               "), edge label: ", edge_info_.GetEdgeLabel());
     }

--- a/cpp/include/gar/reader/arrow_chunk_reader.h
+++ b/cpp/include/gar/reader/arrow_chunk_reader.h
@@ -216,7 +216,8 @@ class AdjListArrowChunkReader {
       chunk_table_.reset();
     }
     if (chunk_index_ >= chunk_num_) {
-      return Status::KeyError("The edge offset ", index, " is out of range [0,",
+      return Status::KeyError("The edge offset ", offset,
+                              " is out of range [0,",
                               edge_info_.GetChunkSize() * chunk_num_,
                               "), edge label: ", edge_info_.GetEdgeLabel());
     }

--- a/cpp/include/gar/reader/chunk_info_reader.h
+++ b/cpp/include/gar/reader/chunk_info_reader.h
@@ -62,8 +62,8 @@ class VertexPropertyChunkInfoReader {
 
   /**
    * @brief Sets chunk position indicator for reader by internal vertex id.
-   *    If internal vertex id is not found, will return Status::KeyError error.
-   *    After seeking to an invalid vertex id, the next call to GetChunk
+   *    If internal vertex id is not found, will return Status::IndexError
+   * error. After seeking to an invalid vertex id, the next call to GetChunk
    * function may undefined, e.g. return an non exist path.
    *
    * @param id the internal vertex id.
@@ -71,9 +71,10 @@ class VertexPropertyChunkInfoReader {
   inline Status seek(IdType id) noexcept {
     chunk_index_ = id / vertex_info_.GetChunkSize();
     if (chunk_index_ >= chunk_num_) {
-      return Status::KeyError("Internal vertex id ", id,
-                              " is not existed in vertex ",
-                              vertex_info_.GetLabel(), ".");
+      return Status::IndexError("Internal vertex id ", id,
+                                " is not out of range [0,",
+                                chunk_num_ * vertex_info_.GetChunkSize(),
+                                ") of vertex ", vertex_info_.GetLabel());
     }
     return Status::OK();
   }
@@ -91,13 +92,14 @@ class VertexPropertyChunkInfoReader {
   /**
    * Sets chunk position indicator to next chunk.
    *
-   * if current chunk is the last chunk, will return Status::OutOfRange
+   * if current chunk is the last chunk, will return Status::IndexError
    *   error.
    */
   Status next_chunk() noexcept {
     if (++chunk_index_ >= chunk_num_) {
-      return Status::OutOfRange("End of the vertex chunk of vertex ",
-                                vertex_info_.GetLabel(), ".");
+      return Status::IndexError(
+          "vertex chunk index ", chunk_index_, " is out-of-bounds for vertex ",
+          vertex_info_.GetLabel(), " chunk num ", chunk_num_);
     }
     return Status::OK();
   }
@@ -171,9 +173,10 @@ class AdjListChunkInfoReader {
   Status seek(IdType index) noexcept {
     chunk_index_ = index / edge_info_.GetChunkSize();
     if (chunk_index_ >= chunk_num_) {
-      return Status::KeyError("The edge offset ", index, " is out of range [0,",
-                              edge_info_.GetChunkSize() * chunk_num_,
-                              "), edge label: ", edge_info_.GetEdgeLabel());
+      return Status::IndexError("The edge offset ", index,
+                                " is out of range [0,",
+                                edge_info_.GetChunkSize() * chunk_num_,
+                                "), edge label: ", edge_info_.GetEdgeLabel());
     }
     return Status::OK();
   }
@@ -189,7 +192,7 @@ class AdjListChunkInfoReader {
   /**
    * Sets chunk position indicator to next chunk.
    *
-   * if current chunk is the last chunk, will return Status::OutOfRange
+   * if current chunk is the last chunk, will return Status::IndexError
    *     error.
    */
   Status next_chunk() {
@@ -197,9 +200,9 @@ class AdjListChunkInfoReader {
     while (chunk_index_ >= chunk_num_) {
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
-        return Status::OutOfRange(
-            "End of the adj list chunk of edge ", edge_info_.GetEdgeLabel(),
-            " of adj list type ", AdjListTypeToString(adj_list_type_), ".");
+        return Status::IndexError("vertex chunk index ", vertex_chunk_index_,
+                                  " is out-of-bounds for vertex chunk num ",
+                                  vertex_chunk_num_);
       }
       chunk_index_ = 0;
       GAR_ASSIGN_OR_RAISE_ERROR(
@@ -280,10 +283,10 @@ class AdjListPropertyChunkInfoReader {
   Status seek(IdType offset) noexcept {
     chunk_index_ = offset / edge_info_.GetChunkSize();
     if (chunk_index_ >= chunk_num_) {
-      return Status::KeyError("The edge offset ", offset,
-                              " is out of range [0,",
-                              edge_info_.GetChunkSize() * chunk_num_,
-                              "), edge label: ", edge_info_.GetEdgeLabel());
+      return Status::IndexError("The edge offset ", offset,
+                                " is out of range [0,",
+                                edge_info_.GetChunkSize() * chunk_num_,
+                                "), edge label: ", edge_info_.GetEdgeLabel());
     }
     return Status::OK();
   }
@@ -300,7 +303,7 @@ class AdjListPropertyChunkInfoReader {
   /**
    * Sets chunk position indicator to next chunk.
    *
-   * if current chunk is the last chunk, will return Status::OutOfRange
+   * if current chunk is the last chunk, will return Status::IndexError
    *  error.
    */
   Status next_chunk() {
@@ -308,10 +311,12 @@ class AdjListPropertyChunkInfoReader {
     while (chunk_index_ >= chunk_num_) {
       ++vertex_chunk_index_;
       if (vertex_chunk_index_ >= vertex_chunk_num_) {
-        return Status::OutOfRange(
-            "End of the property chunk of edge ", edge_info_.GetEdgeLabel(),
-            " of adj list type ", AdjListTypeToString(adj_list_type_),
-            ", property group ", property_group_, ".");
+        return Status::IndexError(
+            "vertex chunk index ", vertex_chunk_index_,
+            " is out-of-bounds for vertex chunk num ", vertex_chunk_num_,
+            " of edge ", edge_info_.GetEdgeLabel(), " of adj list type ",
+            AdjListTypeToString(adj_list_type_), ", property group ",
+            property_group_, ".");
       }
       chunk_index_ = 0;
       GAR_ASSIGN_OR_RAISE_ERROR(
@@ -347,9 +352,8 @@ ConstructVertexPropertyChunkInfoReader(
   VertexInfo vertex_info;
   GAR_ASSIGN_OR_RAISE(vertex_info, graph_info.GetVertexInfo(label));
   if (!vertex_info.ContainPropertyGroup(property_group)) {
-    return Status::Invalid("The vertex ", label,
-                           " doesn't contain property group ", property_group,
-                           ".");
+    return Status::KeyError("No property group ", property_group, " in vertex ",
+                            label, ".");
   }
   return VertexPropertyChunkInfoReader(vertex_info, property_group,
                                        graph_info.GetPrefix());
@@ -372,9 +376,9 @@ static inline Result<AdjListChunkInfoReader> ConstructAdjListChunkInfoReader(
   GAR_ASSIGN_OR_RAISE(edge_info,
                       graph_info.GetEdgeInfo(src_label, edge_label, dst_label));
   if (!edge_info.ContainAdjList(adj_list_type)) {
-    return Status::Invalid("The edge ", edge_label, " of adj list type ",
-                           AdjListTypeToString(adj_list_type),
-                           " doesn't exist.");
+    return Status::KeyError("The adjacent list type ",
+                            AdjListTypeToString(adj_list_type),
+                            " doesn't exist in edge ", edge_label, ".");
   }
 
   return AdjListChunkInfoReader(edge_info, adj_list_type,
@@ -401,11 +405,15 @@ ConstructAdjListPropertyChunkInfoReader(const GraphInfo& graph_info,
   EdgeInfo edge_info;
   GAR_ASSIGN_OR_RAISE(edge_info,
                       graph_info.GetEdgeInfo(src_label, edge_label, dst_label));
+  if (!edge_info.ContainAdjList(adj_list_type)) {
+    return Status::KeyError("The adjacent list type ",
+                            AdjListTypeToString(adj_list_type),
+                            " doesn't exist in edge ", edge_label, ".");
+  }
   if (!edge_info.ContainPropertyGroup(property_group, adj_list_type)) {
-    return Status::Invalid("The edge ", edge_label, " of adj list type ",
-                           AdjListTypeToString(adj_list_type),
-                           " doesn't contain property group ", property_group,
-                           ".");
+    return Status::KeyError("No property group ", property_group, " in edge ",
+                            edge_label, " with adj list type ",
+                            AdjListTypeToString(adj_list_type), ".");
   }
 
   return AdjListPropertyChunkInfoReader(edge_info, property_group,

--- a/cpp/include/gar/reader/chunk_info_reader.h
+++ b/cpp/include/gar/reader/chunk_info_reader.h
@@ -280,7 +280,8 @@ class AdjListPropertyChunkInfoReader {
   Status seek(IdType offset) noexcept {
     chunk_index_ = offset / edge_info_.GetChunkSize();
     if (chunk_index_ >= chunk_num_) {
-      return Status::KeyError("The edge offset ", index, " is out of range [0,",
+      return Status::KeyError("The edge offset ", offset,
+                              " is out of range [0,",
                               edge_info_.GetChunkSize() * chunk_num_,
                               "), edge label: ", edge_info_.GetEdgeLabel());
     }

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -69,7 +69,8 @@ void StringBuilderRecursive(std::ostringstream& stream, Head&& head) {
 }
 
 template <typename Head, typename... Tail>
-void StringBuilderRecursive(std::ostringstream& stream, Head&& head, Tail&&... tail) {
+void StringBuilderRecursive(std::ostringstream& stream, Head&& head,
+                            Tail&&... tail) {
   StringBuilderRecursive(stream, std::forward<Head>(head));
   StringBuilderRecursive(stream, std::forward<Tail>(tail)...);
 }

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -87,16 +87,26 @@ std::string StringBuilder(Args&&... args) {
  * An enum class representing the status codes for success or error outcomes.
  */
 enum class StatusCode : unsigned char {
+  // success status
   kOK = 0,
+  // error status for failed key lookups
   kKeyError,
+  // error status for type errors
   kTypeError,
+  // error status for invalid data
   kInvalid,
+  // error status when an index is out of bounds
   kIndexError,
+  // error status for out-of-memory conditions
   kOutOfMemory,
+  // error status when some IO-related operation failed
   kIOError,
+  // error status when some yaml parse related operation failed
   kYamlError,
+  // error status when some arrow-related operation failed
   kArrowError,
 
+  // error status for unknown errors
   kUnknownError,
 };
 

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef GAR_UTILS_STATUS_H_
 #define GAR_UTILS_STATUS_H_
 
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -61,6 +62,26 @@ limitations under the License.
 
 namespace GAR_NAMESPACE_INTERNAL {
 
+namespace util {
+template <typename Head>
+void StringBuilderRecursive(std::ostream& stream, Head&& head) {
+  stream << head;
+}
+
+template <typename Head, typename... Tail>
+void StringBuilderRecursive(std::ostream& stream, Head&& head, Tail&&... tail) {
+  StringBuilderRecursive(stream, std::forward<Head>(head));
+  StringBuilderRecursive(stream, std::forward<Tail>(tail)...);
+}
+
+template <typename... Args>
+std::string StringBuilder(Args&&... args) {
+  std::ostringstream ss;
+  StringBuilderRecursive(ss, std::forward<Args>(args)...);
+  return ss.str();
+}
+}  // namespace util
+
 /**
  * An enum class representing the status codes for success or error outcomes.
  */
@@ -69,15 +90,13 @@ enum class StatusCode : unsigned char {
   kKeyError,
   kTypeError,
   kInvalid,
-  kInvalidValue,
-  kInvalidArgument,
-  kInvalidOperation,
   kOutOfRange,
   kOutOfMemory,
   kEndOfChunk,
   kIOError,
   kYamlError,
   kArrowError,
+  kNotImplemented,
 
   kUnknownError,
 };
@@ -128,96 +147,112 @@ class Status {
   /** Returns a success status. */
   inline static Status OK() { return Status(); }
 
+  template <typename... Args>
+  static Status FromArgs(StatusCode code, Args... args) {
+    return Status(code, util::StringBuilder(std::forward<Args>(args)...));
+  }
+
   /** Returns an error status when some IO-related operation failed. */
-  static Status IOError(const std::string& msg = "") {
-    return Status(StatusCode::kIOError, msg);
+  template <typename... Args>
+  static Status IOError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kIOError, std::forward<Args>(args)...);
   }
 
   /** Returns an error status for failed key lookups. */
-  static Status KeyError(const std::string& msg = "") {
-    return Status(StatusCode::kKeyError, msg);
+  template <typename... Args>
+  static Status KeyError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kKeyError, std::forward<Args>(args)...);
   }
 
   /** Returns an error status for failed type matches. */
-  static Status TypeError(const std::string& msg = "") {
-    return Status(StatusCode::kTypeError, msg);
+  template <typename... Args>
+  static Status TypeError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kTypeError,
+                            std::forward<Args>(args)...);
   }
 
   /**
    * Returns an error status for invalid data (for example a string that fails
    * parsing).
    */
-  static Status Invalid(const std::string& msg = "") {
-    return Status(StatusCode::kInvalid, msg);
-  }
-
-  static Status InvalidValue(const std::string& msg = "") {
-    return Status(StatusCode::kInvalidValue, msg);
-  }
-
-  static Status InvalidArgument(const std::string& msg = "") {
-    return Status(StatusCode::kInvalidArgument, msg);
-  }
-
-  static Status InvalidOperation(const std::string& msg = "") {
-    return Status(StatusCode::kInvalidOperation, msg);
+  template <typename... Args>
+  static Status Invalid(Args&&... args) {
+    return Status::FromArgs(StatusCode::kInvalid, std::forward<Args>(args)...);
   }
 
   /**
    * Return an error status for value is out of range (for example next_chunk
    * is out of range)
    */
-  static Status OutOfRange(const std::string& msg = "") {
-    return Status(StatusCode::kOutOfRange, msg);
+  template <typename... Args>
+  static Status OutOfRange(Args&&... args) {
+    return Status::FromArgs(StatusCode::kOutOfRange,
+                            std::forward<Args>(args)...);
   }
 
-  static Status EndOfChunk(const std::string& msg = "") {
-    return Status(StatusCode::kEndOfChunk, msg);
+  template <typename... Args>
+  static Status EndOfChunk(Args&&... args) {
+    return Status::FromArgs(StatusCode::kEndOfChunk,
+                            std::forward<Args>(args)...);
   }
 
   /** Return an error status when some yaml-cpp related operation failed. */
-  static Status YamlError(const std::string& msg = "") {
-    return Status(StatusCode::kYamlError, msg);
+  template <typename... Args>
+  static Status YamlError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kYamlError,
+                            std::forward<Args>(args)...);
   }
 
   /** Return an error status when some arrow-related operation failed. */
-  static Status ArrowError(const std::string& msg = "") {
-    return Status(StatusCode::kArrowError, msg);
+  template <typename... Args>
+  static Status ArrowError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kArrowError,
+                            std::forward<Args>(args)...);
   }
 
   /** Return an error status for unknown errors. */
-  static Status UnknownError(const std::string& msg = "") {
-    return Status(StatusCode::kArrowError, msg);
+  template <typename... Args>
+  static Status UnknownError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kUnknownError,
+                            std::forward<Args>(args)...);
   }
 
   /** Return true iff the status indicates success. */
-  bool ok() const { return (state_ == nullptr); }
+  constexpr bool ok() const { return (state_ == nullptr); }
 
   /** Return true iff the status indicates a key lookup error. */
-  bool IsKeyError() const { return code() == StatusCode::kKeyError; }
+  constexpr bool IsKeyError() const { return code() == StatusCode::kKeyError; }
   /** Return true iff the status indicates a type match error. */
-  bool IsTypeError() const { return code() == StatusCode::kTypeError; }
+  constexpr bool IsTypeError() const {
+    return code() == StatusCode::kTypeError;
+  }
   /** Return true iff the status indicates invalid data. */
-  bool IsInvalid() const { return code() == StatusCode::kInvalid; }
-  bool IsInvalidValue() const { return code() == StatusCode::kInvalidValue; }
-  bool IsInvalidArgument() const {
-    return code() == StatusCode::kInvalidArgument;
+  constexpr bool IsInvalid() const { return code() == StatusCode::kInvalid; }
+  constexpr bool IsOutOfRange() const {
+    return code() == StatusCode::kOutOfRange;
   }
-  bool IsInvalidOperation() const {
-    return code() == StatusCode::kInvalidOperation;
+  constexpr bool IsEndOfChunk() const {
+    return code() == StatusCode::kEndOfChunk;
   }
-  bool IsOutOfRange() const { return code() == StatusCode::kOutOfRange; }
-  bool IsEndOfChunk() const { return code() == StatusCode::kEndOfChunk; }
   /** Return true iff the status indicates an yaml-cpp related failure. */
-  bool IsYamlError() const { return code() == StatusCode::kYamlError; }
+  constexpr bool IsYamlError() const {
+    return code() == StatusCode::kYamlError;
+  }
   /** Return true iff the status indicates an arrow-related failure. */
-  bool IsArrowError() const { return code() == StatusCode::kArrowError; }
+  constexpr bool IsArrowError() const {
+    return code() == StatusCode::kArrowError;
+  }
 
   /** Return the StatusCode value attached to this status. */
-  StatusCode code() const { return ok() ? StatusCode::kOK : state_->code; }
+  constexpr StatusCode code() const {
+    return ok() ? StatusCode::kOK : state_->code;
+  }
 
   /** Return the specific error message attached to this status. */
-  std::string message() const { return ok() ? "" : state_->msg; }
+  const std::string& message() const {
+    static const std::string no_message = "";
+    return ok() ? no_message : state_->msg;
+  }
 
  private:
   void deleteState() {

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -97,7 +97,6 @@ enum class StatusCode : unsigned char {
   kIOError,
   kYamlError,
   kArrowError,
-  kNotImplemented,
 
   kUnknownError,
 };

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -93,7 +93,6 @@ enum class StatusCode : unsigned char {
   kInvalid,
   kIndexError,
   kOutOfMemory,
-  kEndOfChunk,
   kIOError,
   kYamlError,
   kArrowError,
@@ -190,12 +189,6 @@ class Status {
                             std::forward<Args>(args)...);
   }
 
-  template <typename... Args>
-  static Status EndOfChunk(Args&&... args) {
-    return Status::FromArgs(StatusCode::kEndOfChunk,
-                            std::forward<Args>(args)...);
-  }
-
   /** Return an error status when some yaml parse related operation failed. */
   template <typename... Args>
   static Status YamlError(Args&&... args) {
@@ -231,9 +224,6 @@ class Status {
   /** Return true iff the status indicates an index out of bounds. */
   constexpr bool IsIndexError() const {
     return code() == StatusCode::kIndexError;
-  }
-  constexpr bool IsEndOfChunk() const {
-    return code() == StatusCode::kEndOfChunk;
   }
   /** Return true iff the status indicates an yaml parse related failure. */
   constexpr bool IsYamlError() const {

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -91,7 +91,7 @@ enum class StatusCode : unsigned char {
   kKeyError,
   kTypeError,
   kInvalid,
-  kOutOfRange,
+  kIndexError,
   kOutOfMemory,
   kEndOfChunk,
   kIOError,
@@ -181,12 +181,12 @@ class Status {
   }
 
   /**
-   * Return an error status for value is out of range (for example next_chunk
-   * is out of range)
+   * Return an error status when an index is out of bounds.
+   *
    */
   template <typename... Args>
-  static Status OutOfRange(Args&&... args) {
-    return Status::FromArgs(StatusCode::kOutOfRange,
+  static Status IndexError(Args&&... args) {
+    return Status::FromArgs(StatusCode::kIndexError,
                             std::forward<Args>(args)...);
   }
 
@@ -196,7 +196,7 @@ class Status {
                             std::forward<Args>(args)...);
   }
 
-  /** Return an error status when some yaml-cpp related operation failed. */
+  /** Return an error status when some yaml parse related operation failed. */
   template <typename... Args>
   static Status YamlError(Args&&... args) {
     return Status::FromArgs(StatusCode::kYamlError,
@@ -228,13 +228,14 @@ class Status {
   }
   /** Return true iff the status indicates invalid data. */
   constexpr bool IsInvalid() const { return code() == StatusCode::kInvalid; }
-  constexpr bool IsOutOfRange() const {
-    return code() == StatusCode::kOutOfRange;
+  /** Return true iff the status indicates an index out of bounds. */
+  constexpr bool IsIndexError() const {
+    return code() == StatusCode::kIndexError;
   }
   constexpr bool IsEndOfChunk() const {
     return code() == StatusCode::kEndOfChunk;
   }
-  /** Return true iff the status indicates an yaml-cpp related failure. */
+  /** Return true iff the status indicates an yaml parse related failure. */
   constexpr bool IsYamlError() const {
     return code() == StatusCode::kYamlError;
   }

--- a/cpp/include/gar/utils/status.h
+++ b/cpp/include/gar/utils/status.h
@@ -64,12 +64,12 @@ namespace GAR_NAMESPACE_INTERNAL {
 
 namespace util {
 template <typename Head>
-void StringBuilderRecursive(std::ostream& stream, Head&& head) {
+void StringBuilderRecursive(std::ostringstream& stream, Head&& head) {
   stream << head;
 }
 
 template <typename Head, typename... Tail>
-void StringBuilderRecursive(std::ostream& stream, Head&& head, Tail&&... tail) {
+void StringBuilderRecursive(std::ostringstream& stream, Head&& head, Tail&&... tail) {
   StringBuilderRecursive(stream, std::forward<Head>(head));
   StringBuilderRecursive(stream, std::forward<Tail>(tail)...);
 }

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -234,7 +234,7 @@ class EdgesBuilder {
    * @param e The edge to add.
    * @param validate_level The validate level for this operation,
    * which is the builder's validate level by default.
-   * @return Status: ok or Status::InvalidOperation error.
+   * @return Status: ok or Status::Invalid error.
    */
   Status AddEdge(const Edge& e, const ValidateLevel& validate_level =
                                     ValidateLevel::default_validate) {

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -200,7 +200,7 @@ class VerticesBuilder {
    * @param index The given index, -1 means the next unused index.
    * @param validate_level The validate level for this operation,
    * which is the builder's validate level by default.
-   * @return Status: ok or Status::InvalidOperation error.
+   * @return Status: ok or Status::Invalid error.
    */
   Status AddVertex(
       Vertex& v, IdType index = -1,  // NOLINT
@@ -256,7 +256,7 @@ class VerticesBuilder {
    * @param v The vertex to add.
    * @param index The given index, -1 means the next unused index.
    * @param validate_level The validate level for this operation.
-   * @return Status: ok or Status::InvalidOperation error.
+   * @return Status: ok or Status::Invalid error.
    */
   Status validate(const Vertex& v, IdType index,
                   ValidateLevel validate_level) const;

--- a/cpp/src/arrow_chunk_reader.cc
+++ b/cpp/src/arrow_chunk_reader.cc
@@ -58,9 +58,10 @@ Status AdjListArrowChunkReader::seek_src(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The source internal id ", id, " is out of range [0,",
+        edge_info_.GetSrcChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -91,9 +92,10 @@ Status AdjListArrowChunkReader::seek_dst(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The destination internal id ", id, " is out of range [0,",
+        edge_info_.GetDstChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -149,9 +151,10 @@ Status AdjListPropertyArrowChunkReader::seek_src(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The source internal id ", id, " is out of range [0,",
+        edge_info_.GetSrcChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -182,9 +185,10 @@ Status AdjListPropertyArrowChunkReader::seek_dst(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The destination internal id ", id, " is out of range [0,",
+        edge_info_.GetDstChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;

--- a/cpp/src/arrow_chunk_reader.cc
+++ b/cpp/src/arrow_chunk_reader.cc
@@ -39,7 +39,9 @@ VertexPropertyArrowChunkReader::GetChunk() noexcept {
 Result<std::pair<IdType, IdType>>
 VertexPropertyArrowChunkReader::GetRange() noexcept {
   if (chunk_table_ == nullptr) {
-    return Status::InvalidOperation("The GetRange operation is not invalid.");
+    return Status::Invalid(
+        "The chunk table is not initialized, please call "
+        "GetChunk() first.");
   }
   IdType row_offset = seek_id_ - chunk_index_ * vertex_info_.GetChunkSize();
   return std::make_pair(seek_id_,
@@ -49,13 +51,16 @@ VertexPropertyArrowChunkReader::GetRange() noexcept {
 Status AdjListArrowChunkReader::seek_src(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_source) {
-    return Status::InvalidOperation(
-        "The seek_src operation is invalid in reader.");
+    return Status::Invalid("The seek_src operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -79,13 +84,16 @@ Status AdjListArrowChunkReader::seek_src(IdType id) noexcept {
 Status AdjListArrowChunkReader::seek_dst(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_dest &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
-    return Status::InvalidOperation(
-        "The seek_dst operation is invalid in reader.");
+    return Status::Invalid("The seek_dst operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -134,13 +142,16 @@ Result<IdType> AdjListArrowChunkReader::GetRowNumOfChunk() noexcept {
 Status AdjListPropertyArrowChunkReader::seek_src(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_source) {
-    return Status::InvalidOperation(
-        "The seek_src operation is invalid in reader.");
+    return Status::Invalid("The seek_src operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -164,13 +175,16 @@ Status AdjListPropertyArrowChunkReader::seek_src(IdType id) noexcept {
 Status AdjListPropertyArrowChunkReader::seek_dst(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_dest &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
-    return Status::InvalidOperation(
-        "The seek_dst operation is invalid in reader.");
+    return Status::Invalid("The seek_dst operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -398,7 +398,8 @@ Status EdgeChunkWriter::validate(
     field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
-          "The data type for destination column should be INT64, but got ",
+          "The data type for destination index column should be INT64, but "
+          "got ",
           field->type()->name());
     }
   }
@@ -517,7 +518,7 @@ Status EdgeChunkWriter::WriteOffsetChunk(
   int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
   if (index == -1) {
     return Status::Invalid("The offset column ", GeneralParams::kOffsetCol,
-                           " is not exist in the input table");
+                           " does not exist in the input table");
   }
   auto in_table = input_table->SelectColumns({index}).ValueOrDie();
   GAR_ASSIGN_OR_RAISE(auto suffix, edge_info_.GetAdjListOffsetFilePath(
@@ -539,14 +540,14 @@ Status EdgeChunkWriter::WriteAdjListChunk(
   if (index == -1) {
     return Status::Invalid("The source index column ",
                            GeneralParams::kSrcIndexCol,
-                           " is not exist in the input table");
+                           " does not exist in the input table");
   }
   indices.push_back(index);
   index = schema->GetFieldIndex(GeneralParams::kDstIndexCol);
   if (index == -1) {
     return Status::Invalid("The destination index column ",
                            GeneralParams::kDstIndexCol,
-                           " is not exist in the input table");
+                           " does not exist in the input table");
   }
   indices.push_back(index);
   auto in_table = input_table->SelectColumns(indices).ValueOrDie();
@@ -575,7 +576,7 @@ Status EdgeChunkWriter::WritePropertyChunk(
       return Status::Invalid("Column named ", property.name,
                              " of property group ", property_group, " of edge ",
                              edge_info_.GetEdgeLabel(),
-                             " is not exist in the input table.");
+                             " does not exist in the input table.");
     }
     indices.push_back(indice);
   }

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -122,7 +122,7 @@ Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
                             " vertex info.");
   }
   if (chunk_index < 0) {
-    return Status::Invalid("The chunk index is negative.");
+    return Status::IndexError("Negative chunk index ", chunk_index, ".");
   }
   return Status::OK();
 }
@@ -277,7 +277,9 @@ Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
   }
   // weak & strong validate for count or index
   if (count_or_index1 < 0 || count_or_index2 < 0) {
-    return Status::Invalid("The count or index must be non-negative.");
+    return Status::IndexError(
+        "The count or index must be non-negative, but got ", count_or_index1,
+        " and ", count_or_index2, ".");
   }
   return Status::OK();
 }
@@ -343,7 +345,7 @@ Status EdgeChunkWriter::validate(
     int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
     if (index == -1) {
       return Status::Invalid("The offset column ", GeneralParams::kOffsetCol,
-                             " is not exist in the input table");
+                             " does not exist in the input table");
     }
     auto field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
@@ -381,7 +383,7 @@ Status EdgeChunkWriter::validate(
     if (index == -1) {
       return Status::Invalid("The source index column ",
                              GeneralParams::kSrcIndexCol,
-                             " is not exist in the input table");
+                             " does not exist in the input table");
     }
     auto field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
@@ -393,7 +395,7 @@ Status EdgeChunkWriter::validate(
     if (index == -1) {
       return Status::Invalid("The destination index column ",
                              GeneralParams::kDstIndexCol,
-                             " is not exist in the input table");
+                             " does not exist in the input table");
     }
     field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -81,16 +81,13 @@ Result<std::shared_ptr<arrow::Table>> ExecutePlanAndCollectAsTable(
   // stop producing
   plan->StopProducing();
   // plan mark finished
-  auto future = plan->finished();
-  if (!future.status().ok()) {
-    return Status::ArrowError(future.status().ToString());
-  }
+  RETURN_NOT_ARROW_OK(plan->finished().status());
   return response_table;
 }
 
 // implementations for VertexPropertyChunkWriter
 
-// Check if the opeartion of writing vertices number is allowed.
+// Check if the operation of writing vertices number is allowed.
 Status VertexPropertyWriter::validate(const IdType& count,
                                       ValidateLevel validate_level) const
     noexcept {
@@ -102,13 +99,12 @@ Status VertexPropertyWriter::validate(const IdType& count,
     return Status::OK();
   // weak & strong validate
   if (count < 0) {
-    return Status::InvalidOperation(
-        "the number of vertices must be non-negative");
+    return Status::Invalid("The number of vertices is negative");
   }
   return Status::OK();
 }
 
-// Check if the opeartion of copying a file as a chunk is allowed.
+// Check if the operation of copying a file as a chunk is allowed.
 Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
                                       IdType chunk_index,
                                       ValidateLevel validate_level) const
@@ -121,32 +117,37 @@ Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
     return Status::OK();
   // weak & strong validate
   if (!vertex_info_.ContainPropertyGroup(property_group)) {
-    return Status::InvalidOperation(
-        "the property group does not exist in the vertex info");
+    return Status::Invalid("The property group ", property_group,
+                           " does not exist in ", vertex_info_.GetLabel(),
+                           " vertex info.");
   }
-  if (chunk_index < 0)
-    return Status::InvalidOperation("invalid vertex chunk index");
+  if (chunk_index < 0) {
+    return Status::Invalid("The chunk index is negative");
+  }
   return Status::OK();
 }
 
-// Check if the opeartion of writing a table as a chunk is allowed.
+// Check if the operation of writing a table as a chunk is allowed.
 Status VertexPropertyWriter::validate(
     const std::shared_ptr<arrow::Table>& input_table,
     const PropertyGroup& property_group, IdType chunk_index,
     ValidateLevel validate_level) const noexcept {
   // use the writer's validate level
-  if (validate_level == ValidateLevel::default_validate)
+  if (validate_level == ValidateLevel::default_validate) {
     validate_level = validate_level_;
+  }
   // no validate
-  if (validate_level == ValidateLevel::no_validate)
+  if (validate_level == ValidateLevel::no_validate) {
     return Status::OK();
+  }
   // validate property_group & chunk_index
   GAR_RETURN_NOT_OK(validate(property_group, chunk_index, validate_level));
   // weak validate for the input_table
   if (input_table->num_rows() > vertex_info_.GetChunkSize()) {
-    return Status::OutOfRange(
-        "the number of rows in the input table is larger than the vertex chunk "
-        "size");
+    return Status::Invalid("The number of rows of input table is ",
+                           input_table->num_rows(),
+                           " which is larger than the vertex chunk size",
+                           vertex_info_.GetChunkSize(), ".");
   }
   // strong validate for the input_table
   if (validate_level == ValidateLevel::strong_validate) {
@@ -154,16 +155,16 @@ Status VertexPropertyWriter::validate(
     for (auto& property : property_group.GetProperties()) {
       int indice = schema->GetFieldIndex(property.name);
       if (indice == -1) {
-        return Status::InvalidOperation("property: " + property.name +
-                                        " not found");
+        return Status::Invalid("Property ", property.name,
+                               " of property group ", property_group,
+                               " does not exist in the input table.");
       }
       auto field = schema->field(indice);
       if (DataType::ArrowDataTypeToDataType(field->type()) != property.type) {
-        std::string err_msg =
-            "invalid data type for property: " + property.name +
-            ", defined as " + property.type.ToTypeName() + ", but got " +
-            DataType::ArrowDataTypeToDataType(field->type()).ToTypeName();
-        return Status::TypeError(err_msg);
+        return Status::TypeError(
+            "The data type of property: ", property.name, " is ",
+            property.type.ToTypeName(), ", but got ",
+            DataType::ArrowDataTypeToDataType(field->type()).ToTypeName(), ".");
       }
     }
   }
@@ -204,9 +205,10 @@ Status VertexPropertyWriter::WriteChunk(
   for (auto& property : property_group.GetProperties()) {
     int indice = schema->GetFieldIndex(property.name);
     if (indice == -1) {
-      std::string msg = "invalid property: " + property.name +
-                        " vertex: " + vertex_info_.GetLabel();
-      return Status::InvalidOperation(msg);
+      return Status::Invalid("Property ", property.name, " of property group ",
+                             property_group, " of vertex ",
+                             vertex_info_.GetLabel(),
+                             " does not exist in the input table.");
     }
     indices.push_back(indice);
   }
@@ -269,14 +271,14 @@ Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
     return Status::OK();
   // weak & strong validate for adj list type
   if (!edge_info_.ContainAdjList(adj_list_type_)) {
-    return Status::InvalidOperation(
-        "the adj list type " +
-        std::string(AdjListTypeToString(adj_list_type_)) +
-        "  does not exist in the edge info");
+    return Status::Invalid(
+        "Adj list type ", AdjListTypeToString(adj_list_type_),
+        " does not exist in the ", edge_info_.GetEdgeLabel(), " edge info.");
   }
   // weak & strong validate for count or index
-  if (count_or_index1 < 0 || count_or_index2 < 0)
-    return Status::InvalidOperation("the count or index must be non-negative");
+  if (count_or_index1 < 0 || count_or_index2 < 0) {
+    return Status::Invalid("The count or index must be non-negative.");
+  }
   return Status::OK();
 }
 
@@ -294,8 +296,9 @@ Status EdgeChunkWriter::validate(const PropertyGroup& property_group,
   GAR_RETURN_NOT_OK(validate(vertex_chunk_index, chunk_index, validate_level));
   // weak & strong validate for property group
   if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_)) {
-    return Status::InvalidOperation(
-        "the property group does not exist in the edge info");
+    return Status::Invalid("Property group ", property_group,
+                           " does not exist in the ", edge_info_.GetEdgeLabel(),
+                           " edge info.");
   }
   return Status::OK();
 }
@@ -315,33 +318,37 @@ Status EdgeChunkWriter::validate(
   // weak validate for the input table
   if (adj_list_type_ != AdjListType::ordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
-    return Status::InvalidOperation(
-        "the adj list type has to be ordered_by_source or ordered_by_dest, but "
+    return Status::Invalid(
+        "The adj list type has to be ordered_by_source or ordered_by_dest, but "
         "got " +
         std::string(AdjListTypeToString(adj_list_type_)));
   }
   if (adj_list_type_ == AdjListType::ordered_by_source &&
       input_table->num_rows() > edge_info_.GetSrcChunkSize() + 1) {
-    return Status::OutOfRange(
-        "the number of rows in the input table is larger than the offset table "
-        "size for a vertex chunk");
+    return Status::Invalid(
+        "The number of rows of input offset table is ", input_table->num_rows(),
+        " which is larger than the offset size of source vertex chunk ",
+        edge_info_.GetSrcChunkSize() + 1, ".");
   }
   if (adj_list_type_ == AdjListType::ordered_by_dest &&
       input_table->num_rows() > edge_info_.GetDstChunkSize() + 1) {
-    return Status::OutOfRange(
-        "the number of rows in the input table is larger than the offset table "
-        "size for a vertex chunk");
+    return Status::Invalid(
+        "The number of rows of input offset table is ", input_table->num_rows(),
+        " which is larger than the offset size of destination vertex chunk ",
+        edge_info_.GetSrcChunkSize() + 1, ".");
   }
   // strong validate for the input_table
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();
     int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
-    if (index == -1)
-      return Status::InvalidOperation("the offset column is not provided");
+    if (index == -1) {
+      return Status::Invalid("The offset column ", GeneralParams::kOffsetCol,
+                             " is not exist in the input table");
+    }
     auto field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
-          "the data type for offset column should be INT64, but got " +
+          "The data type for offset column should be INT64, but got ",
           field->type()->name());
     }
   }
@@ -362,29 +369,36 @@ Status EdgeChunkWriter::validate(
   GAR_RETURN_NOT_OK(validate(vertex_chunk_index, chunk_index, validate_level));
   // weak validate for the input table
   if (input_table->num_rows() > edge_info_.GetChunkSize()) {
-    return Status::OutOfRange(
-        "the number of rows in the input table is larger than the edge chunk "
-        "size");
+    return Status::Invalid(
+        "The number of rows of input table is ", input_table->num_rows(),
+        " which is larger than the ", edge_info_.GetEdgeLabel(),
+        " edge chunk size ", edge_info_.GetChunkSize(), ".");
   }
-  // stong validate for the input table
+  // strong validate for the input table
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();
     int index = schema->GetFieldIndex(GeneralParams::kSrcIndexCol);
-    if (index == -1)
-      return Status::InvalidOperation("the source column is not provided");
+    if (index == -1) {
+      return Status::Invalid("The source index column ",
+                             GeneralParams::kSrcIndexCol,
+                             " is not exist in the input table");
+    }
     auto field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
-          "the data type for source column should be INT64, but got " +
+          "The data type for source index column should be INT64, but got ",
           field->type()->name());
     }
     index = schema->GetFieldIndex(GeneralParams::kDstIndexCol);
-    if (index == -1)
-      return Status::InvalidOperation("the destination column is not provided");
+    if (index == -1) {
+      return Status::Invalid("The destination index column ",
+                             GeneralParams::kDstIndexCol,
+                             " is not exist in the input table");
+    }
     field = schema->field(index);
     if (field->type()->id() != arrow::Type::INT64) {
       return Status::TypeError(
-          "the data type for destination column should be INT64, but got " +
+          "The data type for destination column should be INT64, but got ",
           field->type()->name());
     }
   }
@@ -406,23 +420,28 @@ Status EdgeChunkWriter::validate(
   GAR_RETURN_NOT_OK(validate(property_group, vertex_chunk_index, chunk_index,
                              validate_level));
   // weak validate for the input table
-  if (input_table->num_rows() > edge_info_.GetChunkSize())
-    return Status::OutOfRange();
+  if (input_table->num_rows() > edge_info_.GetChunkSize()) {
+    return Status::Invalid(
+        "The number of rows of input table is ", input_table->num_rows(),
+        " which is larger than the ", edge_info_.GetEdgeLabel(),
+        " edge chunk size ", edge_info_.GetChunkSize(), ".");
+  }
   // strong validate for the input table
   if (validate_level == ValidateLevel::strong_validate) {
     auto schema = input_table->schema();
     for (auto& property : property_group.GetProperties()) {
       int indice = schema->GetFieldIndex(property.name);
-      if (indice == -1)
-        return Status::InvalidOperation("property: " + property.name +
-                                        " not found");
+      if (indice == -1) {
+        return Status::Invalid("Property ", property.name,
+                               " of property group ", property_group,
+                               " does not exist in the input table.");
+      }
       auto field = schema->field(indice);
       if (DataType::ArrowDataTypeToDataType(field->type()) != property.type) {
-        std::string err_msg =
-            "invalid data type for property: " + property.name +
-            ", defined as " + property.type.ToTypeName() + ", but got " +
-            DataType::ArrowDataTypeToDataType(field->type()).ToTypeName();
-        return Status::TypeError(err_msg);
+        return Status::TypeError(
+            "The data type of property: ", property.name, " is ",
+            property.type.ToTypeName(), ", but got ",
+            DataType::ArrowDataTypeToDataType(field->type()).ToTypeName(), ".");
       }
     }
   }
@@ -496,8 +515,10 @@ Status EdgeChunkWriter::WriteOffsetChunk(
   GAR_ASSIGN_OR_RAISE(auto file_type, edge_info_.GetFileType(adj_list_type_));
   auto schema = input_table->schema();
   int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
-  if (index == -1)
-    return Status::InvalidOperation("the offset column is not provided");
+  if (index == -1) {
+    return Status::Invalid("The offset column ", GeneralParams::kOffsetCol,
+                           " is not exist in the input table");
+  }
   auto in_table = input_table->SelectColumns({index}).ValueOrDie();
   GAR_ASSIGN_OR_RAISE(auto suffix, edge_info_.GetAdjListOffsetFilePath(
                                        vertex_chunk_index, adj_list_type_));
@@ -515,12 +536,18 @@ Status EdgeChunkWriter::WriteAdjListChunk(
   indices.clear();
   auto schema = input_table->schema();
   int index = schema->GetFieldIndex(GeneralParams::kSrcIndexCol);
-  if (index == -1)
-    return Status::InvalidOperation("the source column is not provided");
+  if (index == -1) {
+    return Status::Invalid("The source index column ",
+                           GeneralParams::kSrcIndexCol,
+                           " is not exist in the input table");
+  }
   indices.push_back(index);
   index = schema->GetFieldIndex(GeneralParams::kDstIndexCol);
-  if (index == -1)
-    return Status::InvalidOperation("the destination column is not provided");
+  if (index == -1) {
+    return Status::Invalid("The destination index column ",
+                           GeneralParams::kDstIndexCol,
+                           " is not exist in the input table");
+  }
   indices.push_back(index);
   auto in_table = input_table->SelectColumns(indices).ValueOrDie();
 
@@ -545,9 +572,10 @@ Status EdgeChunkWriter::WritePropertyChunk(
   for (auto& property : property_group.GetProperties()) {
     int indice = schema->GetFieldIndex(property.name);
     if (indice == -1) {
-      std::string msg = "invalid property: " + property.name +
-                        " edge: " + edge_info_.GetEdgeLabel();
-      return Status::InvalidOperation(msg);
+      return Status::Invalid("Property ", property.name, " of property group ",
+                             property_group, " of edge ",
+                             edge_info_.GetEdgeLabel(),
+                             " is not exist in the input table.");
     }
     indices.push_back(indice);
   }
@@ -765,15 +793,14 @@ Result<std::shared_ptr<arrow::Table>> EdgeChunkWriter::sortTable(
                                                     {}, table_source_options)
                     .ValueOrDie();
   AsyncGeneratorType sink_gen;
-  if (!arrow_acero_namespace::MakeExecNode(
-           "order_by_sink", plan.get(), {source},
-           arrow_acero_namespace::OrderBySinkNodeOptions{
-               arrow::compute::SortOptions{{arrow::compute::SortKey{
-                   column_name, arrow::compute::SortOrder::Ascending}}},
-               &sink_gen})
-           .ok()) {
-    return Status::InvalidOperation();
-  }
+  RETURN_NOT_ARROW_OK(
+      arrow_acero_namespace::MakeExecNode(
+          "order_by_sink", plan.get(), {source},
+          arrow_acero_namespace::OrderBySinkNodeOptions{
+              arrow::compute::SortOptions{{arrow::compute::SortKey{
+                  column_name, arrow::compute::SortOrder::Ascending}}},
+              &sink_gen})
+          .status());
   return ExecutePlanAndCollectAsTable(*exec_context, plan,
                                       input_table->schema(), sink_gen);
 }

--- a/cpp/src/arrow_chunk_writer.cc
+++ b/cpp/src/arrow_chunk_writer.cc
@@ -99,7 +99,7 @@ Status VertexPropertyWriter::validate(const IdType& count,
     return Status::OK();
   // weak & strong validate
   if (count < 0) {
-    return Status::Invalid("The number of vertices is negative");
+    return Status::Invalid("The number of vertices is negative.");
   }
   return Status::OK();
 }
@@ -117,12 +117,12 @@ Status VertexPropertyWriter::validate(const PropertyGroup& property_group,
     return Status::OK();
   // weak & strong validate
   if (!vertex_info_.ContainPropertyGroup(property_group)) {
-    return Status::Invalid("The property group ", property_group,
-                           " does not exist in ", vertex_info_.GetLabel(),
-                           " vertex info.");
+    return Status::KeyError("The property group ", property_group,
+                            " does not exist in ", vertex_info_.GetLabel(),
+                            " vertex info.");
   }
   if (chunk_index < 0) {
-    return Status::Invalid("The chunk index is negative");
+    return Status::Invalid("The chunk index is negative.");
   }
   return Status::OK();
 }
@@ -155,7 +155,7 @@ Status VertexPropertyWriter::validate(
     for (auto& property : property_group.GetProperties()) {
       int indice = schema->GetFieldIndex(property.name);
       if (indice == -1) {
-        return Status::Invalid("Property ", property.name,
+        return Status::Invalid("Column named ", property.name,
                                " of property group ", property_group,
                                " does not exist in the input table.");
       }
@@ -205,9 +205,9 @@ Status VertexPropertyWriter::WriteChunk(
   for (auto& property : property_group.GetProperties()) {
     int indice = schema->GetFieldIndex(property.name);
     if (indice == -1) {
-      return Status::Invalid("Property ", property.name, " of property group ",
-                             property_group, " of vertex ",
-                             vertex_info_.GetLabel(),
+      return Status::Invalid("Column named ", property.name,
+                             " of property group ", property_group,
+                             " of vertex ", vertex_info_.GetLabel(),
                              " does not exist in the input table.");
     }
     indices.push_back(indice);
@@ -271,7 +271,7 @@ Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
     return Status::OK();
   // weak & strong validate for adj list type
   if (!edge_info_.ContainAdjList(adj_list_type_)) {
-    return Status::Invalid(
+    return Status::KeyError(
         "Adj list type ", AdjListTypeToString(adj_list_type_),
         " does not exist in the ", edge_info_.GetEdgeLabel(), " edge info.");
   }
@@ -296,9 +296,9 @@ Status EdgeChunkWriter::validate(const PropertyGroup& property_group,
   GAR_RETURN_NOT_OK(validate(vertex_chunk_index, chunk_index, validate_level));
   // weak & strong validate for property group
   if (!edge_info_.ContainPropertyGroup(property_group, adj_list_type_)) {
-    return Status::Invalid("Property group ", property_group,
-                           " does not exist in the ", edge_info_.GetEdgeLabel(),
-                           " edge info.");
+    return Status::KeyError("Property group ", property_group,
+                            " does not exist in the ",
+                            edge_info_.GetEdgeLabel(), " edge info.");
   }
   return Status::OK();
 }
@@ -432,7 +432,7 @@ Status EdgeChunkWriter::validate(
     for (auto& property : property_group.GetProperties()) {
       int indice = schema->GetFieldIndex(property.name);
       if (indice == -1) {
-        return Status::Invalid("Property ", property.name,
+        return Status::Invalid("Column named ", property.name,
                                " of property group ", property_group,
                                " does not exist in the input table.");
       }
@@ -572,8 +572,8 @@ Status EdgeChunkWriter::WritePropertyChunk(
   for (auto& property : property_group.GetProperties()) {
     int indice = schema->GetFieldIndex(property.name);
     if (indice == -1) {
-      return Status::Invalid("Property ", property.name, " of property group ",
-                             property_group, " of edge ",
+      return Status::Invalid("Column named ", property.name,
+                             " of property group ", property_group, " of edge ",
                              edge_info_.GetEdgeLabel(),
                              " is not exist in the input table.");
     }

--- a/cpp/src/chunk_info_reader.cc
+++ b/cpp/src/chunk_info_reader.cc
@@ -30,9 +30,10 @@ Status AdjListChunkInfoReader::seek_src(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The source internal id ", id, " is out of range [0,",
+        edge_info_.GetSrcChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -62,9 +63,10 @@ Status AdjListChunkInfoReader::seek_dst(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The destination internal id ", id, " is out of range [0,",
+        edge_info_.GetDstChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -93,9 +95,10 @@ Status AdjListPropertyChunkInfoReader::seek_src(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The source internal id ", id, " is out of range [0,",
+        edge_info_.GetSrcChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -124,9 +127,10 @@ Status AdjListPropertyChunkInfoReader::seek_dst(IdType id) noexcept {
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("No vertex with internal id ", id,
-                            " exists in edge ", edge_info_.GetEdgeLabel(),
-                            " reader.");
+    return Status::IndexError(
+        "The destination internal id ", id, " is out of range [0,",
+        edge_info_.GetDstChunkSize() * vertex_chunk_num_, ") of edge ",
+        edge_info_.GetEdgeLabel(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;

--- a/cpp/src/chunk_info_reader.cc
+++ b/cpp/src/chunk_info_reader.cc
@@ -23,13 +23,16 @@ namespace GAR_NAMESPACE_INTERNAL {
 Status AdjListChunkInfoReader::seek_src(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_source) {
-    return Status::InvalidOperation(
-        "The seek_src operation is invalid in reader.");
+    return Status::Invalid("The seek_src operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -52,13 +55,16 @@ Status AdjListChunkInfoReader::seek_src(IdType id) noexcept {
 Status AdjListChunkInfoReader::seek_dst(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_dest &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
-    return Status::InvalidOperation(
-        "The seek_dst operation is invalid in reader.");
+    return Status::Invalid("The seek_dst operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -80,13 +86,16 @@ Status AdjListChunkInfoReader::seek_dst(IdType id) noexcept {
 Status AdjListPropertyChunkInfoReader::seek_src(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_source) {
-    return Status::InvalidOperation(
-        "The seek_src operation is invalid in reader.");
+    return Status::Invalid("The seek_src operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetSrcChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -108,13 +117,16 @@ Status AdjListPropertyChunkInfoReader::seek_src(IdType id) noexcept {
 Status AdjListPropertyChunkInfoReader::seek_dst(IdType id) noexcept {
   if (adj_list_type_ != AdjListType::unordered_by_dest &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
-    return Status::InvalidOperation(
-        "The seek_dst operation is invalid in reader.");
+    return Status::Invalid("The seek_dst operation is invalid in edge ",
+                           edge_info_.GetEdgeLabel(), " reader with ",
+                           AdjListTypeToString(adj_list_type_), " type.");
   }
 
   IdType new_vertex_chunk_index = id / edge_info_.GetDstChunkSize();
   if (new_vertex_chunk_index >= vertex_chunk_num_) {
-    return Status::KeyError("The id " + std::to_string(id) + " not exist.");
+    return Status::KeyError("No vertex with internal id ", id,
+                            " exists in edge ", edge_info_.GetEdgeLabel(),
+                            " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;

--- a/cpp/src/edges_builder.cc
+++ b/cpp/src/edges_builder.cc
@@ -36,9 +36,9 @@ Status EdgesBuilder::validate(const Edge& e,
         "The edge builder has been saved, can not add "
         "new edges any more");
   }
-  // invalid adj list type
+  // adj list type not exits in edge info
   if (!edge_info_.ContainAdjList(adj_list_type_)) {
-    return Status::Invalid(
+    return Status::KeyError(
         "Adj list type ", AdjListTypeToString(adj_list_type_),
         " does not exist in the ", edge_info_.GetEdgeLabel(), " edge info.");
   }
@@ -48,9 +48,9 @@ Status EdgesBuilder::validate(const Edge& e,
     for (auto& property : e.GetProperties()) {
       // check if the property is contained
       if (!edge_info_.ContainProperty(property.first)) {
-        return Status::Invalid("Property with name ", property.first,
-                               " is not contained in the ",
-                               edge_info_.GetEdgeLabel(), " edge info.");
+        return Status::KeyError("Property with name ", property.first,
+                                " is not contained in the ",
+                                edge_info_.GetEdgeLabel(), " edge info.");
       }
       // check if the property type is correct
       auto type = edge_info_.GetPropertyType(property.first).value();

--- a/cpp/src/filesystem.cc
+++ b/cpp/src/filesystem.cc
@@ -116,7 +116,8 @@ Result<std::shared_ptr<arrow::Table>> FileSystem::ReadFileToTable(
     break;
   }
   default:
-    return Status::Invalid("File type is invalid.");
+    return Status::Invalid("Unsupported file type: ",
+                           FileTypeToString(file_type));
   }
   // cast string array to large string array as we need concatenate chunks in
   // some places, e.g., in vineyard
@@ -238,10 +239,8 @@ Status FileSystem::WriteTableToFile(const std::shared_ptr<arrow::Table>& table,
     break;
   }
   default:
-    std::string message =
-        "Invalid file type: " + std::string(FileTypeToString(file_type)) +
-        " for writing.";
-    return Status::Invalid(message);
+    return Status::Invalid(
+        "Unsupported file type: ", FileTypeToString(file_type), " for wrting.");
   }
   return Status::OK();
 }
@@ -289,7 +288,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
       // the arrow parser would delete the trailing slash which we don't want to
       *out_path = uri.host() + uri.path();
     } else {
-      return Status::Invalid("Unrecognized filesystem type in URI: " +
+      return Status::Invalid("Unrecognized filesystem type in URI: ",
                              uri_string);
     }
   }

--- a/cpp/src/graph.cc
+++ b/cpp/src/graph.cc
@@ -52,9 +52,9 @@ Status TryToCastToAny(const DataType& type, std::shared_ptr<arrow::Array> array,
   case Type::STRING:
     return CastToAny<Type::STRING>(array, any);
   default:
-    return Status::TypeError();
+    return Status::TypeError("Unsupported type.");
   }
-  return Status::TypeError();
+  return Status::OK();
 }
 
 Vertex::Vertex(IdType id,

--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -108,7 +108,7 @@ Status VertexInfo::Save(const std::string& path) const {
 
 Result<EdgeInfo> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
   if (yaml == nullptr) {
-    return Status::Invalid("yaml is nullptr");
+    return Status::Invalid("yaml shared pointer is nullptr.");
   }
   std::string src_label = yaml->operator[]("src_label").As<std::string>();
   std::string edge_label = yaml->operator[]("edge_label").As<std::string>();

--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -25,7 +25,7 @@ namespace GAR_NAMESPACE_INTERNAL {
 
 Result<VertexInfo> VertexInfo::Load(std::shared_ptr<Yaml> yaml) {
   if (yaml == nullptr) {
-    return Status::YamlError("yaml is nullptr");
+    return Status::Invalid("yaml shared pointer is nullptr");
   }
   std::string label = yaml->operator[]("label").As<std::string>();
   IdType chunk_size =
@@ -70,7 +70,7 @@ Result<VertexInfo> VertexInfo::Load(std::shared_ptr<Yaml> yaml) {
 
 Result<std::string> VertexInfo::Dump() const noexcept {
   if (!IsValidated()) {
-    return Status::Invalid();
+    return Status::Invalid("The vertex info is not validated");
   }
   ::Yaml::Node node;
   node["label"] = label_;
@@ -108,7 +108,7 @@ Status VertexInfo::Save(const std::string& path) const {
 
 Result<EdgeInfo> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
   if (yaml == nullptr) {
-    return Status::YamlError("yaml is nullptr");
+    return Status::Invalid("yaml is nullptr");
   }
   std::string src_label = yaml->operator[]("src_label").As<std::string>();
   std::string edge_label = yaml->operator[]("edge_label").As<std::string>();
@@ -183,7 +183,7 @@ Result<EdgeInfo> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
 
 Result<std::string> EdgeInfo::Dump() const noexcept {
   if (!IsValidated()) {
-    return Status::Invalid();
+    return Status::Invalid("The edge info is not validated.");
   }
   ::Yaml::Node node;
   node["src_label"] = src_label_;
@@ -333,7 +333,7 @@ Result<GraphInfo> GraphInfo::Load(const std::string& input,
 
 Result<std::string> GraphInfo::Dump() const noexcept {
   if (!IsValidated()) {
-    return Status::Invalid();
+    return Status::Invalid("The graph info is not validated.");
   }
   ::Yaml::Node node;
   node["name"] = name_;

--- a/cpp/src/reader_utils.cc
+++ b/cpp/src/reader_utils.cc
@@ -48,7 +48,10 @@ Result<std::pair<IdType, IdType>> GetAdjListOffsetOfVertex(
   } else if (adj_list_type == AdjListType::ordered_by_dest) {
     vertex_chunk_size = edge_info.GetDstChunkSize();
   } else {
-    return Status::Invalid("The adj list type is invalid.");
+    return Status::Invalid(
+        "The adj list type has to be ordered_by_source or ordered_by_dest, but "
+        "got " +
+        std::string(AdjListTypeToString(adj_list_type)));
   }
 
   IdType offset_chunk_index = vid / vertex_chunk_size;

--- a/cpp/src/utils.cc
+++ b/cpp/src/utils.cc
@@ -85,9 +85,8 @@ Result<const void*> GetArrowArrayData(
     return reinterpret_cast<const void*>(
         std::dynamic_pointer_cast<arrow::NullArray>(array).get());
   } else {
-    std::string err = "Array type - " + array->type()->ToString() +
-                      " is not supported yet...";
-    return Status::TypeError(err);
+    return Status::TypeError("Array type - ", array->type()->ToString(),
+                             " is not supported yet...");
   }
 }
 

--- a/cpp/src/version_parser.cc
+++ b/cpp/src/version_parser.cc
@@ -106,7 +106,7 @@ Result<InfoVersion> InfoVersion::Parse(
     version.version_ = parserVersionImpl(version_str);
     version.user_define_types_ = parseUserDefineTypesImpl(version_str);
   } catch (const std::exception& e) {
-    return Status::Invalid("Invalid version string: " + version_str);
+    return Status::Invalid("Invalid version string: ", version_str);
   }
   return version;
 }

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -37,15 +37,15 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
   }
   // the start vertex index must be aligned with the chunk size
   if (start_vertex_index_ % vertex_info_.GetChunkSize() != 0) {
-    return Status::Invalid("The start vertex index ", start_vertex_index_,
-                           " is not aligned with the chunk size ",
-                           vertex_info_.GetChunkSize());
+    return Status::IndexError("The start vertex index ", start_vertex_index_,
+                              " is not aligned with the chunk size ",
+                              vertex_info_.GetChunkSize());
   }
   // the vertex index must larger than start index
   if (index != -1 && index < start_vertex_index_) {
-    return Status::Invalid("The vertex index ", index,
-                           " is smaller than the start index ",
-                           start_vertex_index_);
+    return Status::IndexError("The vertex index ", index,
+                              " is smaller than the start index ",
+                              start_vertex_index_);
   }
 
   // strong validate
@@ -53,9 +53,9 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
     for (auto& property : v.GetProperties()) {
       // check if the property is contained
       if (!vertex_info_.ContainProperty(property.first)) {
-        return Status::Invalid("Property with name ", property.first,
-                               " is not contained in the ",
-                               vertex_info_.GetLabel(), " vertex info.");
+        return Status::KeyError("Property with name ", property.first,
+                                " is not contained in the ",
+                                vertex_info_.GetLabel(), " vertex info.");
       }
       // check if the property type is correct
       auto type = vertex_info_.GetPropertyType(property.first).value();

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -31,18 +31,21 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
   // weak validate
   // can not add new vertices after dumping
   if (is_saved_) {
-    return Status::InvalidOperation("can not add new vertices after dumping");
+    return Status::Invalid(
+        "The vertices builder has been saved, can not add "
+        "new vertices any more");
   }
   // the start vertex index must be aligned with the chunk size
   if (start_vertex_index_ % vertex_info_.GetChunkSize() != 0) {
-    return Status::InvalidOperation(
-        "the start vertex index must be aligned "
-        "with the chunk size");
+    return Status::Invalid("The start vertex index ", start_vertex_index_,
+                           " is not aligned with the chunk size ",
+                           vertex_info_.GetChunkSize());
   }
   // the vertex index must larger than start index
   if (index != -1 && index < start_vertex_index_) {
-    return Status::InvalidOperation(
-        "the vertex index must be larger than start index");
+    return Status::Invalid("The vertex index ", index,
+                           " is smaller than the start index ",
+                           start_vertex_index_);
   }
 
   // strong validate
@@ -50,9 +53,9 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
     for (auto& property : v.GetProperties()) {
       // check if the property is contained
       if (!vertex_info_.ContainProperty(property.first)) {
-        return Status::InvalidOperation(
-            "invalid property name: " + property.first +
-            ", which is not contained in the vertex info");
+        return Status::Invalid("Property with name ", property.first,
+                               " is not contained in the ",
+                               vertex_info_.GetLabel(), " vertex info.");
       }
       // check if the property type is correct
       auto type = vertex_info_.GetPropertyType(property.first).value();
@@ -95,14 +98,12 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
         }
         break;
       default:
-        return Status::TypeError("unsupported property type");
+        return Status::TypeError("Unsupported property type.");
       }
       if (invalid_type) {
-        std::string err_msg =
-            "invalid data type for property: " + property.first +
-            ", defined as " + type.ToTypeName() + ", but got " +
-            property.second.type().name();
-        return Status::TypeError(err_msg);
+        return Status::TypeError(
+            "Invalid data type for property ", property.first + ", defined as ",
+            type.ToTypeName(), ", but got ", property.second.type().name());
       }
     }
   }
@@ -126,9 +127,9 @@ Status VerticesBuilder::appendToArray(
   case Type::STRING:
     return tryToAppend<Type::STRING>(property_name, array);
   default:
-    return Status::TypeError();
+    return Status::TypeError("Unsupported property type.");
   }
-  return Status::TypeError();
+  return Status::OK();
 }
 
 template <Type type>
@@ -140,14 +141,10 @@ Status VerticesBuilder::tryToAppend(
   typename ConvertToArrowType<type>::BuilderType builder(pool);
   for (auto& v : vertices_) {
     if (v.Empty() || !v.ContainProperty(property_name)) {
-      auto status = builder.AppendNull();
-      if (!status.ok())
-        return Status::ArrowError(status.ToString());
+      RETURN_NOT_ARROW_OK(builder.AppendNull());
     } else {
-      auto status =
-          builder.Append(std::any_cast<CType>(v.GetProperty(property_name)));
-      if (!status.ok())
-        return Status::ArrowError(status.ToString());
+      RETURN_NOT_ARROW_OK(
+          builder.Append(std::any_cast<CType>(v.GetProperty(property_name))));
     }
   }
   array = builder.Finish().ValueOrDie();

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -85,9 +85,9 @@ TEST_CASE("test_vertex_property_arrow_chunk_reader") {
   REQUIRE(range.first == 900);
   REQUIRE(range.second == 903);
   REQUIRE(reader.GetChunkNum() == 10);
-  REQUIRE(reader.next_chunk().IsOutOfRange());
+  REQUIRE(reader.next_chunk().IsIndexError());
 
-  REQUIRE(reader.seek(1024).IsKeyError());
+  REQUIRE(reader.seek(1024).IsIndexError());
 }
 
 TEST_CASE("test_adj_list_arrow_chunk_reader") {
@@ -126,7 +126,7 @@ TEST_CASE("test_adj_list_arrow_chunk_reader") {
   REQUIRE(!result.has_error());
   table = result.value();
   REQUIRE(table->num_rows() == 644);
-  REQUIRE(reader.seek(1024).IsKeyError());
+  REQUIRE(reader.seek(1024).IsIndexError());
 
   // seek src & dst
   REQUIRE(reader.seek_src(100).ok());
@@ -142,7 +142,7 @@ TEST_CASE("test_adj_list_arrow_chunk_reader") {
   table = result.value();
   REQUIRE(table->num_rows() == 4);
 
-  REQUIRE(reader.next_chunk().IsOutOfRange());
+  REQUIRE(reader.next_chunk().IsIndexError());
 }
 
 TEST_CASE("test_adj_list_property_arrow_chunk_reader") {
@@ -182,7 +182,7 @@ TEST_CASE("test_adj_list_property_arrow_chunk_reader") {
   REQUIRE(!result.has_error());
   table = result.value();
   REQUIRE(table->num_rows() == 644);
-  REQUIRE(reader.seek(1024).IsKeyError());
+  REQUIRE(reader.seek(1024).IsIndexError());
 
   // seek src & dst
   REQUIRE(reader.seek_src(100).ok());
@@ -198,7 +198,7 @@ TEST_CASE("test_adj_list_property_arrow_chunk_reader") {
   table = result.value();
   REQUIRE(table->num_rows() == 4);
 
-  REQUIRE(reader.next_chunk().IsOutOfRange());
+  REQUIRE(reader.next_chunk().IsIndexError());
 }
 
 TEST_CASE("test_read_adj_list_offset_chunk_example") {
@@ -236,6 +236,6 @@ TEST_CASE("test_read_adj_list_offset_chunk_example") {
   REQUIRE(!result.has_error());
   array = result.value();
   REQUIRE(array->length() == 4);
-  REQUIRE(reader.next_chunk().IsOutOfRange());
-  REQUIRE(reader.seek(1024).IsKeyError());
+  REQUIRE(reader.next_chunk().IsIndexError());
+  REQUIRE(reader.seek(1024).IsIndexError());
 }

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -121,7 +121,7 @@ TEST_CASE("test_adj_list_arrow_chunk_reader") {
   table = result.value();
   REQUIRE(table->num_rows() == 567);
   REQUIRE(reader.GetRowNumOfChunk() == 667);
-  REQUIRE(reader.next_chunk().IsEndOfChunk());
+  REQUIRE(reader.next_chunk().ok());
   result = reader.GetChunk();
   REQUIRE(!result.has_error());
   table = result.value();
@@ -177,7 +177,7 @@ TEST_CASE("test_adj_list_property_arrow_chunk_reader") {
   REQUIRE(!result.has_error());
   table = result.value();
   REQUIRE(table->num_rows() == 567);
-  REQUIRE(reader.next_chunk().IsEndOfChunk());
+  REQUIRE(reader.next_chunk().ok());
   result = reader.GetChunk();
   REQUIRE(!result.has_error());
   table = result.value();

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -103,7 +103,7 @@ TEST_CASE("test_vertex_property_writer_from_file") {
   p1.name = "invalid_property";
   p1.type = GAR_NAMESPACE::DataType(GAR_NAMESPACE::Type::INT32);
   GAR_NAMESPACE::PropertyGroup pg1({p1}, GAR_NAMESPACE::FileType::CSV);
-  REQUIRE(writer.WriteTable(table, pg1, 0).IsInvalid());
+  REQUIRE(writer.WriteTable(table, pg1, 0).IsKeyError());
   // Property not found in table
   std::shared_ptr<arrow::Table> tmp_table =
       table->RenameColumns({"original_id", "firstName", "lastName", "id"})
@@ -243,13 +243,13 @@ TEST_CASE("test_edge_chunk_writer") {
   GAR_NAMESPACE::EdgeChunkWriter writer2(edge_info, "/tmp/",
                                          invalid_adj_list_type);
   writer2.SetValidateLevel(GAR_NAMESPACE::ValidateLevel::strong_validate);
-  REQUIRE(writer2.WriteAdjListChunk(table, 0, 0).IsInvalid());
+  REQUIRE(writer2.WriteAdjListChunk(table, 0, 0).IsKeyError());
   // Invalid property group
   GAR_NAMESPACE::Property p1;
   p1.name = "invalid_property";
   p1.type = GAR_NAMESPACE::DataType(GAR_NAMESPACE::Type::INT32);
   GAR_NAMESPACE::PropertyGroup pg1({p1}, GAR_NAMESPACE::FileType::CSV);
-  REQUIRE(writer.WritePropertyChunk(table, pg1, 0, 0).IsInvalid());
+  REQUIRE(writer.WritePropertyChunk(table, pg1, 0, 0).IsKeyError());
   // Property not found in table
   GAR_NAMESPACE::PropertyGroup pg2 =
       edge_info.GetPropertyGroup("creationDate", adj_list_type).value();

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -97,7 +97,7 @@ TEST_CASE("test_vertex_property_writer_from_file") {
   REQUIRE(writer.WriteChunk(table, 0).IsInvalid());
   // Invalid chunk id
   auto chunk = table->Slice(0, vertex_info.GetChunkSize());
-  REQUIRE(writer.WriteChunk(chunk, -1).IsInvalid());
+  REQUIRE(writer.WriteChunk(chunk, -1).IsIndexError());
   // Invalid property group
   GAR_NAMESPACE::Property p1;
   p1.name = "invalid_property";
@@ -230,14 +230,14 @@ TEST_CASE("test_edge_chunk_writer") {
 
   // Invalid cases
   // Invalid count or index
-  REQUIRE(writer.WriteEdgesNum(-1, 0).IsInvalid());
-  REQUIRE(writer.WriteEdgesNum(0, -1).IsInvalid());
-  REQUIRE(writer.WriteVerticesNum(-1).IsInvalid());
+  REQUIRE(writer.WriteEdgesNum(-1, 0).IsIndexError());
+  REQUIRE(writer.WriteEdgesNum(0, -1).IsIndexError());
+  REQUIRE(writer.WriteVerticesNum(-1).IsIndexError());
   // Out of range
   REQUIRE(writer.WriteOffsetChunk(table, 0).IsInvalid());
   // Invalid chunk id
-  REQUIRE(writer.WriteAdjListChunk(table, -1, 0).IsInvalid());
-  REQUIRE(writer.WriteAdjListChunk(table, 0, -1).IsInvalid());
+  REQUIRE(writer.WriteAdjListChunk(table, -1, 0).IsIndexError());
+  REQUIRE(writer.WriteAdjListChunk(table, 0, -1).IsIndexError());
   // Invalid adj list type
   auto invalid_adj_list_type = GAR_NAMESPACE::AdjListType::unordered_by_dest;
   GAR_NAMESPACE::EdgeChunkWriter writer2(edge_info, "/tmp/",

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -92,25 +92,25 @@ TEST_CASE("test_vertex_property_writer_from_file") {
 
   // Invalid cases
   // Invalid vertices number
-  REQUIRE(writer.WriteVerticesNum(-1).IsInvalidOperation());
+  REQUIRE(writer.WriteVerticesNum(-1).IsInvalid());
   // Out of range
-  REQUIRE(writer.WriteChunk(table, 0).IsOutOfRange());
+  REQUIRE(writer.WriteChunk(table, 0).IsInvalid());
   // Invalid chunk id
   auto chunk = table->Slice(0, vertex_info.GetChunkSize());
-  REQUIRE(writer.WriteChunk(chunk, -1).IsInvalidOperation());
+  REQUIRE(writer.WriteChunk(chunk, -1).IsInvalid());
   // Invalid property group
   GAR_NAMESPACE::Property p1;
   p1.name = "invalid_property";
   p1.type = GAR_NAMESPACE::DataType(GAR_NAMESPACE::Type::INT32);
   GAR_NAMESPACE::PropertyGroup pg1({p1}, GAR_NAMESPACE::FileType::CSV);
-  REQUIRE(writer.WriteTable(table, pg1, 0).IsInvalidOperation());
+  REQUIRE(writer.WriteTable(table, pg1, 0).IsInvalid());
   // Property not found in table
   std::shared_ptr<arrow::Table> tmp_table =
       table->RenameColumns({"original_id", "firstName", "lastName", "id"})
           .ValueOrDie();
   GAR_NAMESPACE::PropertyGroup pg2 =
       vertex_info.GetPropertyGroup("firstName").value();
-  REQUIRE(writer.WriteTable(tmp_table, pg2, 0).IsInvalidOperation());
+  REQUIRE(writer.WriteTable(tmp_table, pg2, 0).IsInvalid());
   // Invalid data type
   GAR_NAMESPACE::PropertyGroup pg3 = vertex_info.GetPropertyGroup("id").value();
   REQUIRE(writer.WriteTable(tmp_table, pg3, 0).IsTypeError());
@@ -230,34 +230,34 @@ TEST_CASE("test_edge_chunk_writer") {
 
   // Invalid cases
   // Invalid count or index
-  REQUIRE(writer.WriteEdgesNum(-1, 0).IsInvalidOperation());
-  REQUIRE(writer.WriteEdgesNum(0, -1).IsInvalidOperation());
-  REQUIRE(writer.WriteVerticesNum(-1).IsInvalidOperation());
+  REQUIRE(writer.WriteEdgesNum(-1, 0).IsInvalid());
+  REQUIRE(writer.WriteEdgesNum(0, -1).IsInvalid());
+  REQUIRE(writer.WriteVerticesNum(-1).IsInvalid());
   // Out of range
-  REQUIRE(writer.WriteOffsetChunk(table, 0).IsOutOfRange());
+  REQUIRE(writer.WriteOffsetChunk(table, 0).IsInvalid());
   // Invalid chunk id
-  REQUIRE(writer.WriteAdjListChunk(table, -1, 0).IsInvalidOperation());
-  REQUIRE(writer.WriteAdjListChunk(table, 0, -1).IsInvalidOperation());
+  REQUIRE(writer.WriteAdjListChunk(table, -1, 0).IsInvalid());
+  REQUIRE(writer.WriteAdjListChunk(table, 0, -1).IsInvalid());
   // Invalid adj list type
   auto invalid_adj_list_type = GAR_NAMESPACE::AdjListType::unordered_by_dest;
   GAR_NAMESPACE::EdgeChunkWriter writer2(edge_info, "/tmp/",
                                          invalid_adj_list_type);
   writer2.SetValidateLevel(GAR_NAMESPACE::ValidateLevel::strong_validate);
-  REQUIRE(writer2.WriteAdjListChunk(table, 0, 0).IsInvalidOperation());
+  REQUIRE(writer2.WriteAdjListChunk(table, 0, 0).IsInvalid());
   // Invalid property group
   GAR_NAMESPACE::Property p1;
   p1.name = "invalid_property";
   p1.type = GAR_NAMESPACE::DataType(GAR_NAMESPACE::Type::INT32);
   GAR_NAMESPACE::PropertyGroup pg1({p1}, GAR_NAMESPACE::FileType::CSV);
-  REQUIRE(writer.WritePropertyChunk(table, pg1, 0, 0).IsInvalidOperation());
+  REQUIRE(writer.WritePropertyChunk(table, pg1, 0, 0).IsInvalid());
   // Property not found in table
   GAR_NAMESPACE::PropertyGroup pg2 =
       edge_info.GetPropertyGroup("creationDate", adj_list_type).value();
-  REQUIRE(writer.WritePropertyChunk(table, pg2, 0, 0).IsInvalidOperation());
+  REQUIRE(writer.WritePropertyChunk(table, pg2, 0, 0).IsInvalid());
   // Required columns not found
   std::shared_ptr<arrow::Table> tmp_table =
       table->RenameColumns({"creationDate", "tmp_property"}).ValueOrDie();
-  REQUIRE(writer.WriteAdjListChunk(tmp_table, 0, 0).IsInvalidOperation());
+  REQUIRE(writer.WriteAdjListChunk(tmp_table, 0, 0).IsInvalid());
   // Invalid data type
   REQUIRE(writer.WritePropertyChunk(tmp_table, pg2, 0, 0).IsTypeError());
 }

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -65,12 +65,14 @@ TEST_CASE("test_vertices_builder") {
       builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::no_validate).ok());
   REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate)
               .ok());
+  auto st =
+      builder.AddVertex(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate);
   REQUIRE(builder.AddVertex(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate)
-              .IsInvalid());
+              .IsIndexError());
   REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   v.AddProperty("invalid_name", "invalid_value");
-  REQUIRE(builder.AddVertex(v, 0).IsInvalid());
+  REQUIRE(builder.AddVertex(v, 0).IsKeyError());
 
   // clear vertices
   builder.Clear();
@@ -157,7 +159,7 @@ TEST_CASE("test_edges_builder") {
   REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   e.AddProperty("invalid_name", "invalid_value");
-  REQUIRE(builder.AddEdge(e).IsInvalid());
+  REQUIRE(builder.AddEdge(e).IsKeyError());
 
   // clear edges
   builder.Clear();

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -66,11 +66,11 @@ TEST_CASE("test_vertices_builder") {
   REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::weak_validate)
               .ok());
   REQUIRE(builder.AddVertex(v, -2, GAR_NAMESPACE::ValidateLevel::weak_validate)
-              .IsInvalidOperation());
+              .IsInvalid());
   REQUIRE(builder.AddVertex(v, 0, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   v.AddProperty("invalid_name", "invalid_value");
-  REQUIRE(builder.AddVertex(v, 0).IsInvalidOperation());
+  REQUIRE(builder.AddVertex(v, 0).IsInvalid());
 
   // clear vertices
   builder.Clear();
@@ -116,7 +116,7 @@ TEST_CASE("test_vertices_builder") {
   REQUIRE(builder.Dump().ok());
 
   // can not add new vertices after dumping
-  REQUIRE(builder.AddVertex(v).IsInvalidOperation());
+  REQUIRE(builder.AddVertex(v).IsInvalid());
 
   // check the number of vertices dumped
   auto fs = arrow::fs::FileSystemFromUriOrPath(root).ValueOrDie();
@@ -157,7 +157,7 @@ TEST_CASE("test_edges_builder") {
   REQUIRE(builder.AddEdge(e, GAR_NAMESPACE::ValidateLevel::strong_validate)
               .IsTypeError());
   e.AddProperty("invalid_name", "invalid_value");
-  REQUIRE(builder.AddEdge(e).IsInvalidOperation());
+  REQUIRE(builder.AddEdge(e).IsInvalid());
 
   // clear edges
   builder.Clear();
@@ -202,7 +202,7 @@ TEST_CASE("test_edges_builder") {
   REQUIRE(builder.Dump().ok());
 
   // can not add new edges after dumping
-  REQUIRE(builder.AddEdge(e).IsInvalidOperation());
+  REQUIRE(builder.AddEdge(e).IsInvalid());
 
   // check the number of vertices dumped
   auto fs = arrow::fs::FileSystemFromUriOrPath(root).ValueOrDie();

--- a/cpp/test/test_chunk_info_reader.cc
+++ b/cpp/test/test_chunk_info_reader.cc
@@ -135,7 +135,7 @@ TEST_CASE("test_adj_list_chunk_info_reader") {
 
   // seek an invalid src id
   REQUIRE(reader.seek_src(1000).IsKeyError());
-  REQUIRE(reader.seek_dst(100).IsInvalidOperation());
+  REQUIRE(reader.seek_dst(100).IsInvalid());
 
   // test reader to read ordered by dest
   auto maybe_dst_reader = GAR_NAMESPACE::ConstructAdjListChunkInfoReader(
@@ -153,7 +153,7 @@ TEST_CASE("test_adj_list_chunk_info_reader") {
 
   // seek an invalid dst id
   REQUIRE(dst_reader.seek_dst(1000).IsKeyError());
-  REQUIRE(dst_reader.seek_src(100).IsInvalidOperation());
+  REQUIRE(dst_reader.seek_src(100).IsInvalid());
 }
 
 TEST_CASE("test_adj_list_property_chunk_info_reader") {
@@ -222,7 +222,7 @@ TEST_CASE("test_adj_list_property_chunk_info_reader") {
 
   // seek an invalid src id
   REQUIRE(reader.seek_src(1000).IsKeyError());
-  REQUIRE(reader.seek_dst(100).IsInvalidOperation());
+  REQUIRE(reader.seek_dst(100).IsInvalid());
 
   // test reader to read ordered by dest
   maybe_group = graph_info.GetEdgePropertyGroup(
@@ -246,5 +246,5 @@ TEST_CASE("test_adj_list_property_chunk_info_reader") {
 
   // seek an invalid dst id
   REQUIRE(dst_reader.seek_dst(1000).IsKeyError());
-  REQUIRE(dst_reader.seek_src(100).IsInvalidOperation());
+  REQUIRE(dst_reader.seek_src(100).IsInvalid());
 }

--- a/cpp/test/test_chunk_info_reader.cc
+++ b/cpp/test/test_chunk_info_reader.cc
@@ -64,10 +64,10 @@ TEST_CASE("test_vertex_property_chunk_info_reader") {
   chunk_path = maybe_chunk_path.value();
   REQUIRE(chunk_path == root + "/ldbc_sample/parquet/vertex/person/id/chunk9");
   // now is end of the chunks
-  REQUIRE(reader.next_chunk().IsOutOfRange());
+  REQUIRE(reader.next_chunk().IsIndexError());
 
   // test seek the id not in the chunks
-  REQUIRE(reader.seek(100000).IsKeyError());
+  REQUIRE(reader.seek(100000).IsIndexError());
 
   // test Get vertex property chunk num through vertex property chunk info
   // reader
@@ -131,10 +131,10 @@ TEST_CASE("test_adj_list_chunk_info_reader") {
   REQUIRE(chunk_path == root +
                             "/ldbc_sample/parquet/edge/person_knows_person/"
                             "ordered_by_source/adj_list/part9/chunk0");
-  REQUIRE(reader.next_chunk().IsOutOfRange());
+  REQUIRE(reader.next_chunk().IsIndexError());
 
   // seek an invalid src id
-  REQUIRE(reader.seek_src(1000).IsKeyError());
+  REQUIRE(reader.seek_src(1000).IsIndexError());
   REQUIRE(reader.seek_dst(100).IsInvalid());
 
   // test reader to read ordered by dest
@@ -152,7 +152,7 @@ TEST_CASE("test_adj_list_chunk_info_reader") {
                             "ordered_by_dest/adj_list/part1/chunk0");
 
   // seek an invalid dst id
-  REQUIRE(dst_reader.seek_dst(1000).IsKeyError());
+  REQUIRE(dst_reader.seek_dst(1000).IsIndexError());
   REQUIRE(dst_reader.seek_src(100).IsInvalid());
 }
 
@@ -218,10 +218,10 @@ TEST_CASE("test_adj_list_property_chunk_info_reader") {
   REQUIRE(chunk_path == root +
                             "/ldbc_sample/parquet/edge/person_knows_person/"
                             "ordered_by_source/creationDate/part9/chunk0");
-  REQUIRE(reader.next_chunk().IsOutOfRange());
+  REQUIRE(reader.next_chunk().IsIndexError());
 
   // seek an invalid src id
-  REQUIRE(reader.seek_src(1000).IsKeyError());
+  REQUIRE(reader.seek_src(1000).IsIndexError());
   REQUIRE(reader.seek_dst(100).IsInvalid());
 
   // test reader to read ordered by dest
@@ -245,6 +245,6 @@ TEST_CASE("test_adj_list_property_chunk_info_reader") {
                             "ordered_by_dest/creationDate/part1/chunk0");
 
   // seek an invalid dst id
-  REQUIRE(dst_reader.seek_dst(1000).IsKeyError());
+  REQUIRE(dst_reader.seek_dst(1000).IsIndexError());
   REQUIRE(dst_reader.seek_src(100).IsInvalid());
 }

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -50,7 +50,7 @@ TEST_CASE("test_graph_info") {
   REQUIRE(maybe_vertex_info.value().GetPrefix() == "test_vertex_prefix");
   REQUIRE(graph_info.GetVertexInfo("test_not_exist").status().IsKeyError());
   // vertex info already exists
-  REQUIRE(graph_info.AddVertex(vertex_info).IsInvalidOperation());
+  REQUIRE(graph_info.AddVertex(vertex_info).IsInvalid());
 
   // test add edge and get edge info
   REQUIRE(graph_info.GetEdgeInfos().size() == 0);
@@ -70,7 +70,7 @@ TEST_CASE("test_graph_info") {
   REQUIRE(maybe_edge_info.value().GetDstLabel() == dst_label);
   REQUIRE(graph_info.GetEdgeInfo("xxx", "xxx", "xxx").status().IsKeyError());
   // edge info already exists
-  REQUIRE(graph_info.AddEdge(edge_info).IsInvalidOperation());
+  REQUIRE(graph_info.AddEdge(edge_info).IsInvalid());
 
   REQUIRE(graph_info.GetVersion() == version);
 
@@ -104,10 +104,10 @@ TEST_CASE("test_vertex_info") {
   REQUIRE(v_info.GetPropertyGroups().size() == 0);
   REQUIRE(v_info.AddPropertyGroup(pg).ok());
   // same property group can not be added twice
-  REQUIRE(v_info.AddPropertyGroup(pg).IsInvalidOperation());
+  REQUIRE(v_info.AddPropertyGroup(pg).IsInvalid());
   GAR_NAMESPACE::PropertyGroup pg2({p}, GAR_NAMESPACE::FileType::PARQUET);
   // same property can not be put in different property group
-  REQUIRE(v_info.AddPropertyGroup(pg2).IsInvalidOperation());
+  REQUIRE(v_info.AddPropertyGroup(pg2).IsInvalid());
   REQUIRE(v_info.GetPropertyGroups().size() == 1);
 
   GAR_NAMESPACE::Property p2;
@@ -187,7 +187,7 @@ TEST_CASE("test_edge_info") {
   REQUIRE(edge_info.AddAdjList(adj_list_type, file_type).ok());
   REQUIRE(edge_info.ContainAdjList(adj_list_type));
   // same adj list type can not be added twice
-  REQUIRE(edge_info.AddAdjList(adj_list_type, file_type).IsInvalidOperation());
+  REQUIRE(edge_info.AddAdjList(adj_list_type, file_type).IsKeyError());
   auto file_type_result = edge_info.GetFileType(adj_list_type);
   REQUIRE(!file_type_result.has_error());
   REQUIRE(file_type_result.value() == file_type);


### PR DESCRIPTION
## Proposed changes
This change aims to refine the error constructor and fulfill the error message detail for C++ SDK.
- Refine the error constructor with [parameter pack](https://en.cppreference.com/w/cpp/language/parameter_pack), so developers can construct the error by only passing the messages to constructor, no need to concatenate as a string.
- Fulfill the detail message of error in C++ SDK to let user/developer know what the error is about and why it turn out.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Related issue: #140 

