### PR TITLE
[Minor][Spark] Adapt spark yaml format to BLOCK

### DIFF
--- a/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
@@ -18,7 +18,7 @@ package com.alibaba.graphar
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
-import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.{Yaml, DumperOptions}
 import org.yaml.snakeyaml.constructor.Constructor
 import scala.beans.BeanProperty
 
@@ -500,7 +500,12 @@ class EdgeInfo() {
       }
       data.put("adj_lists", adj_list_maps)
     }
-    val yaml = new Yaml()
+    val options = new DumperOptions()
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+    options.setIndent(4)
+    options.setIndicatorIndent(2);
+    options.setPrettyFlow(true)
+    val yaml = new Yaml(options)
     return yaml.dump(data)
   }
 }

--- a/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
@@ -18,7 +18,7 @@ package com.alibaba.graphar
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
-import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.{Yaml, DumperOptions}
 import org.yaml.snakeyaml.constructor.Constructor
 import scala.beans.BeanProperty
 
@@ -284,7 +284,12 @@ class GraphInfo() {
     data.put("edges", edges)
     data.put("prefix", prefix)
     data.put("version", version)
-    val yaml = new Yaml()
+    val options = new DumperOptions()
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+    options.setIndent(4)
+    options.setPrettyFlow(true)
+    options.setIndicatorIndent(2);
+    val yaml = new Yaml(options)
     return yaml.dump(data)
   }
 }

--- a/spark/src/main/scala/com/alibaba/graphar/VertexInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/VertexInfo.scala
@@ -18,7 +18,7 @@ package com.alibaba.graphar
 import java.io.{File, FileInputStream}
 import org.apache.hadoop.fs.{Path, FileSystem}
 import org.apache.spark.sql.{SparkSession}
-import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.{Yaml, DumperOptions}
 import org.yaml.snakeyaml.constructor.Constructor
 import scala.beans.BeanProperty
 
@@ -239,7 +239,12 @@ class VertexInfo() {
       }
       data.put("property_groups", property_group_maps)
     }
-    val yaml = new Yaml()
+    val options = new DumperOptions()
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+    options.setIndent(4)
+    options.setIndicatorIndent(2);
+    options.setPrettyFlow(true)
+    val yaml = new Yaml(options)
     return yaml.dump(data)
   }
 }


### PR DESCRIPTION
## Proposed changes
Current spark generated info yaml can't not be load by C++ SDK, Set the format options to adapt the format to BLOCK which is the format like https://github.com/GraphScope/gar-test/tree/d8dd7fd931a3893f81fa236b7be20952667ac716/ldbc

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

