### PR TITLE
[Feat][C++] Output the error message when access value in Result fail

### DIFF
--- a/cpp/include/gar/external/result.hpp
+++ b/cpp/include/gar/external/result.hpp
@@ -4285,6 +4285,7 @@ auto RESULT_NS_IMPL::detail::throw_bad_result_access(E&& error) -> void
   >;
 
   throw exception_type{
+    error.message(),
     detail::forward<E>(error)
   };
 #endif

--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -1182,7 +1182,7 @@ class GraphInfo {
       noexcept {
     if (vertex2info_.find(label) == vertex2info_.end()) {
       return Status::KeyError("The vertex info of ", label,
-                              "is not found in graph info.");
+                              " is not found in graph info.");
     }
     return vertex2info_.at(label);
   }
@@ -1219,7 +1219,7 @@ class GraphInfo {
       const std::string& label, const std::string& property) const noexcept {
     if (vertex2info_.find(label) == vertex2info_.end()) {
       return Status::KeyError("The vertex info of ", label,
-                              "is not found in graph info.");
+                              " is not found in graph info.");
     }
     return vertex2info_.at(label).GetPropertyGroup(property);
   }

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -178,7 +178,7 @@ TEST_CASE("test_edges_builder") {
     lines++;
     std::string val;
     std::istringstream readstr(line);
-    int64_t s, d;
+    int64_t s = 0, d = 0;
     for (int i = 0; i < 3; i++) {
       getline(readstr, val, '|');
       if (i == 0) {


### PR DESCRIPTION
## Proposed changes
current when access value fail with `Result`, it just output message like:
`error attempting to access value from result containing error`.

This change change the behavior that output the message of error it contain.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Fixed issue: #218 

