### PR TITLE
[Feat][C++] Support List Data Type, use `list<float>` as example

### DIFF
--- a/cpp/include/gar/fwd.h
+++ b/cpp/include/gar/fwd.h
@@ -120,6 +120,7 @@ const std::shared_ptr<DataType>& int64();
 const std::shared_ptr<DataType>& float32();
 const std::shared_ptr<DataType>& float64();
 const std::shared_ptr<DataType>& string();
+const std::shared_ptr<DataType>& list_float32();
 
 namespace util {
 struct FilterOptions;

--- a/cpp/include/gar/fwd.h
+++ b/cpp/include/gar/fwd.h
@@ -73,6 +73,9 @@ class DataType;
 enum FileType { CSV = 0, PARQUET = 1, ORC = 2 };
 enum class AdjListType : uint8_t;
 
+template <typename T>
+class Array;
+
 class InfoVersion;
 
 class Property;

--- a/cpp/include/gar/fwd.h
+++ b/cpp/include/gar/fwd.h
@@ -120,7 +120,7 @@ const std::shared_ptr<DataType>& int64();
 const std::shared_ptr<DataType>& float32();
 const std::shared_ptr<DataType>& float64();
 const std::shared_ptr<DataType>& string();
-const std::shared_ptr<DataType>& list_float32();
+std::shared_ptr<DataType> list(const std::shared_ptr<DataType>& value_type);
 
 namespace util {
 struct FilterOptions;

--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -70,23 +70,7 @@ class Vertex {
    * @return Result: The property value or error.
    */
   template <typename T>
-  inline Result<T> property(const std::string& property) noexcept {
-    if (properties_.find(property) == properties_.end()) {
-      return Status::KeyError("Property with name ", property,
-                              " does not exist in the vertex.");
-    }
-    try {
-      T ret = std::any_cast<T>(properties_[property]);
-      return ret;
-    } catch (const std::bad_any_cast& e) {
-      return Status::TypeError("Any cast failed, the property type of ",
-                               property, " is not matched ", e.what());
-    }
-  }
-
-  template <typename T>
-  Result<std::pair<const T*, int>> list_property(
-      const std::string& property) const;
+  Result<T> property(const std::string& property) const;
 
  private:
   IdType id_;
@@ -130,23 +114,7 @@ class Edge {
    * @return Result: The property value or error.
    */
   template <typename T>
-  inline Result<T> property(const std::string& property) noexcept {
-    if (properties_.find(property) == properties_.end()) {
-      return Status::KeyError("Property with name ", property,
-                              " does not exist in the edge.");
-    }
-    try {
-      T ret = std::any_cast<T>(properties_[property]);
-      return ret;
-    } catch (const std::bad_any_cast& e) {
-      return Status::TypeError("Any cast failed, the property type of ",
-                               property, " is not matched ", e.what());
-    }
-  }
-
-  template <typename T>
-  Result<std::pair<const T*, int>> list_property(
-      const std::string& property) const;
+  inline Result<T> property(const std::string& property) const;
 
  private:
   IdType src_id_, dst_id_;

--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -85,7 +85,8 @@ class Vertex {
   }
 
   template <typename T>
-  Result<std::pair<const T*, int>> list_property(const std::string& property);
+  Result<std::pair<const T*, int>> list_property(
+      const std::string& property) const;
 
  private:
   IdType id_;
@@ -144,7 +145,8 @@ class Edge {
   }
 
   template <typename T>
-  Result<std::pair<const T*, int>> list_property(const std::string& property);
+  Result<std::pair<const T*, int>> list_property(
+      const std::string& property) const;
 
  private:
   IdType src_id_, dst_id_;

--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -36,7 +36,8 @@
 // forward declarations
 namespace arrow {
 class ChunkedArray;
-}
+class Array;
+}  // namespace arrow
 
 namespace GAR_NAMESPACE_INTERNAL {
 
@@ -83,9 +84,13 @@ class Vertex {
     }
   }
 
+  template <typename T>
+  Result<std::pair<const T*, int>> list_property(const std::string& property);
+
  private:
   IdType id_;
   std::map<std::string, std::any> properties_;
+  std::map<std::string, std::shared_ptr<arrow::Array>> list_properties_;
 };
 
 /**
@@ -138,9 +143,13 @@ class Edge {
     }
   }
 
+  template <typename T>
+  Result<std::pair<const T*, int>> list_property(const std::string& property);
+
  private:
   IdType src_id_, dst_id_;
   std::map<std::string, std::any> properties_;
+  std::map<std::string, std::shared_ptr<arrow::Array>> list_properties_;
 };
 
 /**

--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -114,7 +114,7 @@ class Edge {
    * @return Result: The property value or error.
    */
   template <typename T>
-  inline Result<T> property(const std::string& property) const;
+  Result<T> property(const std::string& property) const;
 
  private:
   IdType src_id_, dst_id_;

--- a/cpp/include/gar/util/convert_to_arrow_type.h
+++ b/cpp/include/gar/util/convert_to_arrow_type.h
@@ -28,13 +28,25 @@
 namespace GAR_NAMESPACE_INTERNAL {
 
 /** Struct to convert DataType to arrow::DataType. */
+template <typename T>
+struct CTypeToArrowType {};
+
 template <Type T>
-struct ConvertToArrowType {};
+struct TypeToArrowType {};
 
 #define CONVERT_TO_ARROW_TYPE(type, c_type, arrow_type, array_type,            \
                               builder_type, type_value, str)                   \
   template <>                                                                  \
-  struct ConvertToArrowType<type> {                                            \
+  struct TypeToArrowType<type> {                                               \
+    using CType = c_type;                                                      \
+    using ArrowType = arrow_type;                                              \
+    using ArrayType = array_type;                                              \
+    using BuilderType = builder_type;                                          \
+    static std::shared_ptr<arrow::DataType> TypeValue() { return type_value; } \
+    static const char* type_to_string() { return str; }                        \
+  };                                                                           \
+  template <>                                                                  \
+  struct CTypeToArrowType<c_type> {                                            \
     using CType = c_type;                                                      \
     using ArrowType = arrow_type;                                              \
     using ArrayType = array_type;                                              \

--- a/cpp/include/gar/util/data_type.h
+++ b/cpp/include/gar/util/data_type.h
@@ -110,11 +110,10 @@ class DataType {
   static std::shared_ptr<arrow::DataType> DataTypeToArrowDataType(
       const std::shared_ptr<DataType>& type);
 
-  static const std::shared_ptr<DataType>& ArrowDataTypeToDataType(
+  static std::shared_ptr<DataType> ArrowDataTypeToDataType(
       const std::shared_ptr<arrow::DataType>& type);
 
-  static const std::shared_ptr<DataType>& TypeNameToDataType(
-      const std::string& str);
+  static std::shared_ptr<DataType> TypeNameToDataType(const std::string& str);
 
   /** Return the type category of the DataType. */
   Type id() const { return id_; }

--- a/cpp/include/gar/util/data_type.h
+++ b/cpp/include/gar/util/data_type.h
@@ -51,6 +51,9 @@ enum class Type {
   /** UTF8 variable-length string */
   STRING,
 
+  /** List of some logical data type */
+  LIST,
+
   /** User-defined data type */
   USER_DEFINED,
 
@@ -67,14 +70,21 @@ class DataType {
   DataType() : id_(Type::BOOL) {}
 
   explicit DataType(Type id, const std::string& user_defined_type_name = "")
-      : id_(id), user_defined_type_name_(user_defined_type_name) {}
+      : id_(id),
+        child_(nullptr),
+        user_defined_type_name_(user_defined_type_name) {}
+
+  explicit DataType(Type id, const std::shared_ptr<DataType>& child)
+      : id_(id), child_(std::move(child)), user_defined_type_name_("") {}
 
   DataType(const DataType& other)
       : id_(other.id_),
+        child_(other.child_),
         user_defined_type_name_(other.user_defined_type_name_) {}
 
   explicit DataType(DataType&& other)
       : id_(other.id_),
+        child_(std::move(other.child_)),
         user_defined_type_name_(std::move(other.user_defined_type_name_)) {}
 
   inline DataType& operator=(const DataType& other) = default;
@@ -90,6 +100,8 @@ class DataType {
     }
     return Equals(*other.get());
   }
+
+  const std::shared_ptr<DataType>& value_type() const { return child_; }
 
   bool operator==(const DataType& other) const { return Equals(other); }
 
@@ -111,6 +123,7 @@ class DataType {
 
  private:
   Type id_;
+  std::shared_ptr<DataType> child_;
   std::string user_defined_type_name_;
 };  // struct DataType
 }  // namespace GAR_NAMESPACE_INTERNAL

--- a/cpp/include/gar/util/util.h
+++ b/cpp/include/gar/util/util.h
@@ -126,5 +126,46 @@ struct ValueGetter<std::string> {
 
 }  // namespace util
 
+template <typename T>
+class Array {
+ public:
+  using value_type = T;
+  Array() : data_(nullptr), size_(0) {}
+  Array(T* data, size_t size) : data_(data), size_(size) {}
+  Array(const Array& other) = default;
+  Array(Array&& other) = default;
+  Array& operator=(const Array& other) = default;
+  Array& operator=(Array&& other) = default;
+  ~Array() = default;
+
+  const T& operator[](size_t index) const { return data_[index]; }
+
+  const T* data() const { return data_; }
+
+  size_t size() const { return size_; }
+
+  void resize(size_t size) { size_ = size; }
+
+  void clear() {
+    data_ = nullptr;
+    size_ = 0;
+  }
+
+  bool empty() const { return size_ == 0; }
+
+  void swap(Array& other) {
+    std::swap(data_, other.data_);
+    std::swap(size_, other.size_);
+  }
+
+  const T* begin() { return data_; }
+
+  const T* end() { return data_ + size_; }
+
+ private:
+  const T* data_;
+  size_t size_;
+};
+
 }  // namespace GAR_NAMESPACE_INTERNAL
 #endif  // GAR_UTIL_UTIL_H_

--- a/cpp/include/gar/util/util.h
+++ b/cpp/include/gar/util/util.h
@@ -127,11 +127,11 @@ struct ValueGetter<std::string> {
 }  // namespace util
 
 template <typename T>
-class Array {
+class Array final {
  public:
-  using value_type = T;
+  using ValueType = T;
   Array() : data_(nullptr), size_(0) {}
-  Array(T* data, size_t size) : data_(data), size_(size) {}
+  Array(const T* data, size_t size) : data_(data), size_(size) {}
   Array(const Array& other) = default;
   Array(Array&& other) = default;
   Array& operator=(const Array& other) = default;
@@ -143,8 +143,6 @@ class Array {
   const T* data() const { return data_; }
 
   size_t size() const { return size_; }
-
-  void resize(size_t size) { size_ = size; }
 
   void clear() {
     data_ = nullptr;
@@ -166,6 +164,11 @@ class Array {
   const T* data_;
   size_t size_;
 };
+
+using Int32Array = Array<int32_t>;
+using Int64Array = Array<int64_t>;
+using FloatArray = Array<float>;
+using DoubleArray = Array<double>;
 
 }  // namespace GAR_NAMESPACE_INTERNAL
 #endif  // GAR_UTIL_UTIL_H_

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -79,6 +79,7 @@ class Edge {
    * @param name The name of the property.
    * @param val The value of the property.
    */
+  // TODO(@acezen): Enable the property to be a vector(list).
   inline void AddProperty(const std::string& name, const std::any& val) {
     empty_ = false;
     properties_[name] = val;

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -79,6 +79,7 @@ class Vertex {
    * @param name The name of the property.
    * @param val The value of the property.
    */
+  // TODO(@acezen): Enable the property to be a vector(list).
   inline void AddProperty(const std::string& name, const std::any& val) {
     empty_ = false;
     properties_[name] = val;

--- a/cpp/src/edges_builder.cc
+++ b/cpp/src/edges_builder.cc
@@ -118,37 +118,37 @@ Status EdgesBuilder::validate(const Edge& e,
       switch (type->id()) {
       case Type::BOOL:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::BOOL>::CType)) {
+            typeid(typename TypeToArrowType<Type::BOOL>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::INT32:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::INT32>::CType)) {
+            typeid(typename TypeToArrowType<Type::INT32>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::INT64:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::INT64>::CType)) {
+            typeid(typename TypeToArrowType<Type::INT64>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::FLOAT:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::FLOAT>::CType)) {
+            typeid(typename TypeToArrowType<Type::FLOAT>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::DOUBLE:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::DOUBLE>::CType)) {
+            typeid(typename TypeToArrowType<Type::DOUBLE>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::STRING:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::STRING>::CType)) {
+            typeid(typename TypeToArrowType<Type::STRING>::CType)) {
           invalid_type = true;
         }
         break;
@@ -193,9 +193,9 @@ Status EdgesBuilder::tryToAppend(
     const std::string& property_name,
     std::shared_ptr<arrow::Array>& array,  // NOLINT
     const std::vector<Edge>& edges) {
-  using CType = typename ConvertToArrowType<type>::CType;
+  using CType = typename TypeToArrowType<type>::CType;
   arrow::MemoryPool* pool = arrow::default_memory_pool();
-  typename ConvertToArrowType<type>::BuilderType builder(pool);
+  typename TypeToArrowType<type>::BuilderType builder(pool);
   for (const auto& e : edges) {
     if (e.Empty() || (!e.ContainProperty(property_name))) {
       RETURN_NOT_ARROW_OK(builder.AppendNull());

--- a/cpp/src/graph.cc
+++ b/cpp/src/graph.cc
@@ -97,15 +97,6 @@ Result<std::pair<const T*, int>> Vertex::list_property(
   return std::make_pair(values, array->length());
 }
 
-#define INSTANTIATE_VERTEX_LIST_PROPERTY(T)                           \
-  template Result<std::pair<const T*, int>> Vertex::list_property<T>( \
-      const std::string& name) const;
-
-INSTANTIATE_VERTEX_LIST_PROPERTY(int32_t)
-INSTANTIATE_VERTEX_LIST_PROPERTY(int64_t)
-INSTANTIATE_VERTEX_LIST_PROPERTY(float)
-INSTANTIATE_VERTEX_LIST_PROPERTY(double)
-
 Edge::Edge(
     AdjListArrowChunkReader& adj_list_reader,                          // NOLINT
     std::vector<AdjListPropertyArrowChunkReader>& property_readers) {  // NOLINT
@@ -152,14 +143,16 @@ Result<std::pair<const T*, int>> Edge::list_property(
   return std::make_pair(values, array->length());
 }
 
-#define INSTANTIATE_EDGE_LIST_PROPERTY(T)                           \
-  template Result<std::pair<const T*, int>> Edge::list_property<T>( \
+#define INSTANTIATE_LIST_PROPERTY(T)                                  \
+  template Result<std::pair<const T*, int>> Vertex::list_property<T>( \
+      const std::string& name) const;                                 \
+  template Result<std::pair<const T*, int>> Edge::list_property<T>(   \
       const std::string& name) const;
 
-INSTANTIATE_EDGE_LIST_PROPERTY(int32_t)
-INSTANTIATE_EDGE_LIST_PROPERTY(int64_t)
-INSTANTIATE_EDGE_LIST_PROPERTY(float)
-INSTANTIATE_EDGE_LIST_PROPERTY(double)
+INSTANTIATE_LIST_PROPERTY(int32_t)
+INSTANTIATE_LIST_PROPERTY(int64_t)
+INSTANTIATE_LIST_PROPERTY(float)
+INSTANTIATE_LIST_PROPERTY(double)
 
 IdType EdgeIter::source() {
   adj_list_reader_.seek(cur_offset_);

--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -122,6 +122,10 @@ bool PropertyGroup::IsValidated() const {
     } else {
       check_property_unique_set.insert(p.name);
     }
+    if (p.type->id() == Type::LIST && file_type_ == FileType::CSV) {
+      // list type is not supported in csv file
+      return false;
+    }
   }
   return true;
 }

--- a/cpp/src/vertices_builder.cc
+++ b/cpp/src/vertices_builder.cc
@@ -65,37 +65,37 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
       switch (type->id()) {
       case Type::BOOL:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::BOOL>::CType)) {
+            typeid(typename TypeToArrowType<Type::BOOL>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::INT32:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::INT32>::CType)) {
+            typeid(typename TypeToArrowType<Type::INT32>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::INT64:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::INT64>::CType)) {
+            typeid(typename TypeToArrowType<Type::INT64>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::FLOAT:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::FLOAT>::CType)) {
+            typeid(typename TypeToArrowType<Type::FLOAT>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::DOUBLE:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::DOUBLE>::CType)) {
+            typeid(typename TypeToArrowType<Type::DOUBLE>::CType)) {
           invalid_type = true;
         }
         break;
       case Type::STRING:
         if (property.second.type() !=
-            typeid(typename ConvertToArrowType<Type::STRING>::CType)) {
+            typeid(typename TypeToArrowType<Type::STRING>::CType)) {
           invalid_type = true;
         }
         break;
@@ -138,9 +138,9 @@ template <Type type>
 Status VerticesBuilder::tryToAppend(
     const std::string& property_name,
     std::shared_ptr<arrow::Array>& array) {  // NOLINT
-  using CType = typename ConvertToArrowType<type>::CType;
+  using CType = typename TypeToArrowType<type>::CType;
   arrow::MemoryPool* pool = arrow::default_memory_pool();
-  typename ConvertToArrowType<type>::BuilderType builder(pool);
+  typename TypeToArrowType<type>::BuilderType builder(pool);
   for (auto& v : vertices_) {
     if (v.Empty() || !v.ContainProperty(property_name)) {
       RETURN_NOT_ARROW_OK(builder.AppendNull());

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -82,7 +82,8 @@ TEST_CASE("Graph") {
 
   SECTION("ListProperty") {
     // read file and construct graph info
-    std::string path = root + "/ldbc_sample/parquet/ldbc_sample_with_feature.graph.yml";
+    std::string path =
+        root + "/ldbc_sample/parquet/ldbc_sample_with_feature.graph.yml";
     auto maybe_graph_info = GraphInfo::Load(path);
     REQUIRE(maybe_graph_info.status().ok());
     auto graph_info = maybe_graph_info.value();

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -95,13 +95,13 @@ TEST_CASE("Graph") {
     auto count = 0;
     for (auto it = vertices->begin(); it != vertices->end(); ++it) {
       auto vertex = *it;
-      auto list = vertex.list_property<float>(list_property).value();
-      int len = list.second;
-      for (int i = 0; i < len; i++) {
-        REQUIRE(list.first[i] == static_cast<float>(vertex.id()) + i);
+      auto float_array = vertex.property<FloatArray>(list_property).value();
+      for (size_t i = 0; i < float_array.size(); i++) {
+        REQUIRE(float_array[i] == static_cast<float>(vertex.id()) + i);
       }
       count++;
     }
+    return;
     REQUIRE(count == 903);
   }
 

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -18,6 +18,7 @@
 
 #include "./util.h"
 #include "gar/graph.h"
+#include "gar/util/data_type.h"
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
@@ -93,16 +94,22 @@ TEST_CASE("Graph") {
     REQUIRE(!maybe_vertices_collection.has_error());
     auto vertices = maybe_vertices_collection.value();
     auto count = 0;
-    for (auto it = vertices->begin(); it != vertices->end(); ++it) {
-      auto vertex = *it;
-      auto float_array = vertex.property<FloatArray>(list_property).value();
-      for (size_t i = 0; i < float_array.size(); i++) {
-        REQUIRE(float_array[i] == static_cast<float>(vertex.id()) + i);
+    auto vertex_info = graph_info->GetVertexInfo(label);
+    auto data_type = vertex_info->GetPropertyType(list_property).value();
+    REQUIRE(data_type->id() == Type::LIST);
+    REQUIRE(data_type->value_type()->id() == Type::FLOAT);
+    if (data_type->id() == Type::LIST &&
+        data_type->value_type()->id() == Type::FLOAT) {
+      for (auto it = vertices->begin(); it != vertices->end(); ++it) {
+        auto vertex = *it;
+        auto float_array = vertex.property<FloatArray>(list_property).value();
+        for (size_t i = 0; i < float_array.size(); i++) {
+          REQUIRE(float_array[i] == static_cast<float>(vertex.id()) + i);
+        }
+        count++;
       }
-      count++;
+      REQUIRE(count == 903);
     }
-    return;
-    REQUIRE(count == 903);
   }
 
   SECTION("EdgesCollection") {

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -80,6 +80,30 @@ TEST_CASE("Graph") {
             it_begin.property<int64_t>("id").value());
   }
 
+  SECTION("ListProperty") {
+    // read file and construct graph info
+    std::string path = root + "/ldbc_sample/parquet/ldbc_sample_with_feature.graph.yml";
+    auto maybe_graph_info = GraphInfo::Load(path);
+    REQUIRE(maybe_graph_info.status().ok());
+    auto graph_info = maybe_graph_info.value();
+    std::string label = "person", list_property = "feature";
+    auto maybe_vertices_collection =
+        VerticesCollection::Make(graph_info, label);
+    REQUIRE(!maybe_vertices_collection.has_error());
+    auto vertices = maybe_vertices_collection.value();
+    auto count = 0;
+    for (auto it = vertices->begin(); it != vertices->end(); ++it) {
+      auto vertex = *it;
+      auto list = vertex.list_property<float>(list_property).value();
+      int len = list.second;
+      for (int i = 0; i < len; i++) {
+        REQUIRE(list.first[i] == static_cast<float>(vertex.id()) + i);
+      }
+      count++;
+    }
+    REQUIRE(count == 903);
+  }
+
   SECTION("EdgesCollection") {
     std::string src_label = "person", edge_label = "knows",
                 dst_label = "person";

--- a/docs/file-format.rst
+++ b/docs/file-format.rst
@@ -164,6 +164,7 @@ GraphAr provides a set of built-in data types that are common in real use cases 
 - float
 - double
 - string
+- list (of int32, int64, float, double; not supported by CSV)
 
 .. tip::
 

--- a/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
@@ -44,8 +44,8 @@ object GarType extends Enumeration {
   /** UTF8 variable-length string */
   val STRING = Value(6)
 
-  /** Array of same type */
-  val ARRAY = Value(7)
+  /** List of same type */
+  val LIST = Value(7)
 
   /**
    * Data type in gar to string.
@@ -62,7 +62,7 @@ object GarType extends Enumeration {
     case GarType.FLOAT  => "float"
     case GarType.DOUBLE => "double"
     case GarType.STRING => "string"
-    case GarType.ARRAY  => "array"
+    case GarType.LIST  => "list"
     case _ => throw new IllegalArgumentException("Unknown data type")
   }
 
@@ -81,7 +81,7 @@ object GarType extends Enumeration {
     case "float"  => GarType.FLOAT
     case "double" => GarType.DOUBLE
     case "string" => GarType.STRING
-    case "array"  => GarType.ARRAY
+    case "list"  => GarType.LIST
     case _ => throw new IllegalArgumentException("Unknown data type: " + str)
   }
 }

--- a/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
@@ -62,7 +62,7 @@ object GarType extends Enumeration {
     case GarType.FLOAT  => "float"
     case GarType.DOUBLE => "double"
     case GarType.STRING => "string"
-    case GarType.LIST  => "list"
+    case GarType.LIST   => "list"
     case _ => throw new IllegalArgumentException("Unknown data type")
   }
 
@@ -81,7 +81,7 @@ object GarType extends Enumeration {
     case "float"  => GarType.FLOAT
     case "double" => GarType.DOUBLE
     case "string" => GarType.STRING
-    case "list"  => GarType.LIST
+    case "list"   => GarType.LIST
     case _ => throw new IllegalArgumentException("Unknown data type: " + str)
   }
 }


### PR DESCRIPTION
## Proposed changes
This pull request aims to support `List` data type in GraphAr C++ and add related unit-test
- Support `List` data type by add a `child_` to `DataType` class, implement by nested other logical data type.
- In high level reader, support read list property  in `Vertex`/`Edge`.
yaml example:
```bash
property:
  - name: feature
  - data_type: list<float>
  - is_primary: false
```

NB: since BooleanArray and StringArray'method are not align to NumericalArray, so we only support `list<int32>` `list<int64>`, `list<float>` and `list<double>` at present.

## Types of changes

What types of changes does your code introduce to GraphAr?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
close issue #287 
related to #169 
