### PR TITLE
[BugFix][Spark] Fix the comparison behavior of Property/PropertyGroup/AdjList

### DIFF
--- a/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
@@ -179,6 +179,16 @@ class Property() {
     GarType.StringToGarType(data_type)
   }
 
+  override def equals(that: Any): Boolean = {
+    that match {
+      case other: Property =>
+        this.name == other.name &&
+          this.data_type == other.data_type &&
+          this.is_primary == other.is_primary
+      case _ => false
+    }
+  }
+
   def toMap(): java.util.HashMap[String, Object] = {
     val data = new java.util.HashMap[String, Object]()
     data.put("name", name)
@@ -193,6 +203,16 @@ class PropertyGroup() {
   @BeanProperty var prefix: String = ""
   @BeanProperty var file_type: String = ""
   @BeanProperty var properties = new java.util.ArrayList[Property]()
+
+  override def equals(that: Any): Boolean = {
+    that match {
+      case other: PropertyGroup =>
+        this.prefix == other.prefix &&
+          this.file_type == other.file_type &&
+          this.properties == other.properties
+      case _ => false
+    }
+  }
 
   /** Get file type in gar of property group */
   def getFile_type_in_gar: FileType.Value = {
@@ -222,6 +242,18 @@ class AdjList() {
   @BeanProperty var prefix: String = ""
   @BeanProperty var file_type: String = ""
   @BeanProperty var property_groups = new java.util.ArrayList[PropertyGroup]()
+
+  override def equals(that: Any): Boolean = {
+    that match {
+      case other: AdjList =>
+        this.ordered == other.ordered &&
+          this.aligned_by == other.aligned_by &&
+          this.prefix == other.prefix &&
+          this.file_type == other.file_type &&
+          this.property_groups == other.property_groups
+      case _ => false
+    }
+  }
 
   /** Get file type in gar of adj list */
   def getFile_type_in_gar: FileType.Value = {

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -415,4 +415,43 @@ class GraphInfoSuite extends AnyFunSuite {
     assertThrows[IllegalArgumentException](edge_info.isPrimaryKey("not_exist"))
   }
 
+  test("== of Property/PropertyGroup/AdjList") {
+    val p1 = new Property()
+    val p2 = new Property()
+    assert(p1 == p2)
+    p1.setName("name")
+    assert(p1 != p2)
+    p2.setName("name")
+    assert(p1 == p2)
+    p1.setData_type("INT64")
+    assert(p1 != p2)
+    p2.setData_type("INT64")
+    assert(p1 == p2)
+    val pg1 = new PropertyGroup()
+    val pg2 = new PropertyGroup()
+    assert(pg1 == pg2)
+    pg1.setPrefix("/tmp")
+    assert(pg1 != pg2)
+    pg2.setPrefix("/tmp")
+    assert(pg1 == pg2)
+    pg1.setProperties(
+      new java.util.ArrayList[Property](java.util.Arrays.asList(p1))
+    )
+    assert(pg1 != pg2)
+    pg2.setProperties(
+      new java.util.ArrayList[Property](java.util.Arrays.asList(p2))
+    )
+    assert(pg1 == pg2)
+    val al1 = new AdjList()
+    val al2 = new AdjList()
+    assert(al1 == al2)
+    al1.setProperty_groups(
+      new java.util.ArrayList[PropertyGroup](java.util.Arrays.asList(pg1))
+    )
+    assert(al1 != al2)
+    al2.setProperty_groups(
+      new java.util.ArrayList[PropertyGroup](java.util.Arrays.asList(pg2))
+    )
+    assert(al1 == al2)
+  }
 }


### PR DESCRIPTION
## Proposed changes
This change add `override equals` to `Property`, `PropertyGroup` and `AdjList` to fix the comparison behavior.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
closed issue: #303 
