### PR TITLE
[Feat][Spark] Align info implementation of spark with c++

### DIFF
--- a/pyspark/tests/test_reader.py
+++ b/pyspark/tests/test_reader.py
@@ -83,12 +83,12 @@ def test_edge_reader(spark):
     assert (
         "_graphArEdgeIndex"
         in edge_reader.read_edge_property_group(
-            edge_info.get_property_group("weight", AdjListType.ORDERED_BY_SOURCE)
+            edge_info.get_property_group("weight")
         ).columns
     )
     assert (
         edge_reader.read_edge_property_group(
-            edge_info.get_property_group("weight", AdjListType.ORDERED_BY_SOURCE)
+            edge_info.get_property_group("weight")
         ).count()
         > 0
     )

--- a/pyspark/tests/test_transform.py
+++ b/pyspark/tests/test_transform.py
@@ -26,7 +26,7 @@ GRAPHAR_TESTS_EXAMPLES = Path(__file__).parent.parent.parent.joinpath("testing")
 def test_transform(spark):
     initialize(spark)
     source_path = (
-        GRAPHAR_TESTS_EXAMPLES.joinpath("ldbc_sample/parquet/ldbc_sample.graph.yml")
+        GRAPHAR_TESTS_EXAMPLES.joinpath("new/ldbc_sample/parquet/ldbc_sample.graph.yml")
         .absolute()
         .__str__()
     )

--- a/pyspark/tests/test_writer.py
+++ b/pyspark/tests/test_writer.py
@@ -89,7 +89,7 @@ def test_edge_writer(spark):
 
     edge_writer.write_edges()
     edge_writer.write_edge_properties(
-        edge_info.get_property_group("degree", AdjListType.ORDERED_BY_SOURCE),
+        edge_info.get_property_group("degree"),
     )
     edge_writer.write_edge_properties()
     edge_writer.write_adj_list()

--- a/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/EdgeInfo.scala
@@ -34,6 +34,7 @@ class EdgeInfo() {
   @BeanProperty var directed: Boolean = false
   @BeanProperty var prefix: String = ""
   @BeanProperty var adj_lists = new java.util.ArrayList[AdjList]()
+  @BeanProperty var property_groups = new java.util.ArrayList[PropertyGroup]()
   @BeanProperty var version: String = ""
 
   /**
@@ -108,60 +109,24 @@ class EdgeInfo() {
   }
 
   /**
-   * Get the property groups of adj list type.
-   *
-   * @param adj_list_type
-   *   the input adj list type.
-   * @return
-   *   property group of the input adj list type, if edge info not support the
-   *   adj list type, raise an IllegalArgumentException error.
-   */
-  def getPropertyGroups(
-      adj_list_type: AdjListType.Value
-  ): java.util.ArrayList[PropertyGroup] = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      if (adj_list.getAdjList_type_in_gar == adj_list_type) {
-        return adj_list.getProperty_groups
-      }
-    }
-    throw new IllegalArgumentException(
-      "adj list type not found: " + AdjListType.AdjListTypeToString(
-        adj_list_type
-      )
-    )
-  }
-
-  /**
-   * Check if the edge info contains the property group in certain adj list
-   * structure.
+   * Check if the edge info contains the property group.
    *
    * @param property_group
    *   the property group to check.
-   * @param adj_list_type
-   *   the type of adj list structure.
+   *
    * @return
    *   true if the edge info contains the property group in certain adj list
    *   structure. If edge info not support the given adj list type or not
    *   contains the property group in the adj list structure, return false.
    */
   def containPropertyGroup(
-      property_group: PropertyGroup,
-      adj_list_type: AdjListType.Value
+      property_group: PropertyGroup
   ): Boolean = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      if (adj_list.getAdjList_type_in_gar == adj_list_type) {
-        val property_groups = adj_list.getProperty_groups
-        val len: Int = property_groups.size
-        for (i <- 0 to len - 1) {
-          val pg: PropertyGroup = property_groups.get(i)
-          if (pg == property_group) {
-            return true
-          }
-        }
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      if (pg == property_group) {
+        return true
       }
     }
     return false
@@ -176,19 +141,14 @@ class EdgeInfo() {
    *   true if edge info contains the property, otherwise false.
    */
   def containProperty(property_name: String): Boolean = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      val property_groups = adj_list.getProperty_groups
-      val len: Int = property_groups.size
-      for (i <- 0 to len - 1) {
-        val pg: PropertyGroup = property_groups.get(i)
-        val properties = pg.getProperties
-        val num = properties.size
-        for (j <- 0 to num - 1) {
-          if (properties.get(j).getName == property_name) {
-            return true
-          }
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      val properties = pg.getProperties
+      val num = properties.size
+      for (j <- 0 to num - 1) {
+        if (properties.get(j).getName == property_name) {
+          return true
         }
       }
     }
@@ -196,48 +156,29 @@ class EdgeInfo() {
   }
 
   /**
-   * Get property group that contains property with adj list type.
+   * Get the property group that contains property.
    *
    * @param property_name
    *   name of the property.
-   * @param adj_list_type
-   *   the type of adj list structure.
    * @return
-   *   property group that contains the property. If edge info not support the
-   *   adj list type, or not find the property group that contains the property,
-   *   return false.
+   *   property group that contains the property, otherwise raise
+   *   IllegalArgumentException error.
    */
   def getPropertyGroup(
-      property_name: String,
-      adj_list_type: AdjListType.Value
+      property_name: String
   ): PropertyGroup = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      if (adj_list.getAdjList_type_in_gar == adj_list_type) {
-        val property_groups = adj_list.getProperty_groups
-        val len: Int = property_groups.size
-        for (i <- 0 to len - 1) {
-          val pg: PropertyGroup = property_groups.get(i)
-          val properties = pg.getProperties
-          val num = properties.size
-          for (j <- 0 to num - 1) {
-            if (properties.get(j).getName == property_name) {
-              return pg
-            }
-          }
-          throw new IllegalArgumentException(
-            "property group not found: " + property_name + " in adj list type: " + AdjListType
-              .AdjListTypeToString(
-                adj_list_type
-              )
-          )
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      val properties = pg.getProperties
+      val num = properties.size
+      for (j <- 0 to num - 1) {
+        if (properties.get(j).getName == property_name) {
+          return pg
         }
       }
     }
-    throw new IllegalArgumentException(
-      "adj list type or property group not found."
-    )
+    throw new IllegalArgumentException("Property not found: " + property_name)
   }
 
   /**
@@ -250,23 +191,18 @@ class EdgeInfo() {
    *   raise an IllegalArgumentException error.
    */
   def getPropertyType(property_name: String): GarType.Value = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      val property_groups = adj_list.getProperty_groups
-      val len: Int = property_groups.size
-      for (i <- 0 to len - 1) {
-        val pg: PropertyGroup = property_groups.get(i)
-        val properties = pg.getProperties
-        val num = properties.size
-        for (j <- 0 to num - 1) {
-          if (properties.get(j).getName == property_name) {
-            return properties.get(j).getData_type_in_gar
-          }
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      val properties = pg.getProperties
+      val num = properties.size
+      for (j <- 0 to num - 1) {
+        if (properties.get(j).getName == property_name) {
+          return properties.get(j).getData_type_in_gar
         }
       }
     }
-    throw new IllegalArgumentException("property not found: " + property_name)
+    throw new IllegalArgumentException("Property not found: " + property_name)
   }
 
   /**
@@ -280,40 +216,30 @@ class EdgeInfo() {
    *   error.
    */
   def isPrimaryKey(property_name: String): Boolean = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      val property_groups = adj_list.getProperty_groups
-      val len: Int = property_groups.size
-      for (i <- 0 to len - 1) {
-        val pg: PropertyGroup = property_groups.get(i)
-        val properties = pg.getProperties
-        val num = properties.size
-        for (j <- 0 to num - 1) {
-          if (properties.get(j).getName == property_name) {
-            return properties.get(j).getIs_primary
-          }
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      val properties = pg.getProperties
+      val num = properties.size
+      for (j <- 0 to num - 1) {
+        if (properties.get(j).getName == property_name) {
+          return properties.get(j).getIs_primary
         }
       }
     }
-    throw new IllegalArgumentException("property not found: " + property_name)
+    throw new IllegalArgumentException("Property not found: " + property_name)
   }
 
   /** Get Primary key of edge info. */
   def getPrimaryKey(): String = {
-    val tot: Int = adj_lists.size
-    for (k <- 0 to tot - 1) {
-      val adj_list = adj_lists.get(k)
-      val property_groups = adj_list.getProperty_groups
-      val len: Int = property_groups.size
-      for (i <- 0 to len - 1) {
-        val pg: PropertyGroup = property_groups.get(i)
-        val properties = pg.getProperties
-        val num = properties.size
-        for (j <- 0 to num - 1) {
-          if (properties.get(j).getIs_primary) {
-            return properties.get(j).getName
-          }
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      val properties = pg.getProperties
+      val num = properties.size
+      for (j <- 0 to num - 1) {
+        if (properties.get(j).getIs_primary) {
+          return properties.get(j).getName
         }
       }
     }
@@ -332,17 +258,16 @@ class EdgeInfo() {
     for (k <- 0 to tot - 1) {
       val adj_list = adj_lists.get(k)
       val file_type = adj_list.getFile_type_in_gar
-      val property_groups = adj_list.getProperty_groups
-      val len: Int = property_groups.size
-      for (i <- 0 to len - 1) {
-        val pg: PropertyGroup = property_groups.get(i)
-        val properties = pg.getProperties
-        val num = properties.size
-        if (num == 0) {
-          return false
-        }
-        val pg_file_type = pg.getFile_type_in_gar
+    }
+    val len: Int = property_groups.size
+    for (i <- 0 to len - 1) {
+      val pg: PropertyGroup = property_groups.get(i)
+      val properties = pg.getProperties
+      val num = properties.size
+      if (num == 0) {
+        return false
       }
+      val file_type = pg.getFile_type_in_gar
     }
     return true
   }
@@ -543,7 +468,7 @@ class EdgeInfo() {
       vertex_chunk_index: Long,
       chunk_index: Long
   ): String = {
-    if (containPropertyGroup(property_group, adj_list_type) == false)
+    if (containPropertyGroup(property_group) == false)
       throw new IllegalArgumentException("property group not found.")
     var str: String = property_group.getPrefix
     if (str == "") {
@@ -580,7 +505,7 @@ class EdgeInfo() {
       adj_list_type: AdjListType.Value,
       vertex_chunk_index: Long
   ): String = {
-    if (containPropertyGroup(property_group, adj_list_type) == false)
+    if (containPropertyGroup(property_group) == false)
       throw new IllegalArgumentException("property group not found.")
     var str: String = property_group.getPrefix
     if (str == "") {
@@ -613,7 +538,7 @@ class EdgeInfo() {
       property_group: PropertyGroup,
       adj_list_type: AdjListType.Value
   ): String = {
-    if (containPropertyGroup(property_group, adj_list_type) == false)
+    if (containPropertyGroup(property_group) == false)
       throw new IllegalArgumentException("property group not found.")
     var str: String = property_group.getPrefix
     if (str == "") {
@@ -652,6 +577,14 @@ class EdgeInfo() {
         adj_list_maps.add(adj_lists.get(i).toMap())
       }
       data.put("adj_lists", adj_list_maps)
+    }
+    val property_group_num = property_groups.size()
+    if (property_group_num > 0) {
+      val property_group_maps = new java.util.ArrayList[Object]()
+      for (i <- 0 until property_group_num) {
+        property_group_maps.add(property_groups.get(i).toMap())
+      }
+      data.put("property_groups", property_group_maps)
     }
     val options = new DumperOptions()
     options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)

--- a/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/GraphInfo.scala
@@ -242,7 +242,6 @@ class AdjList() {
   @BeanProperty var aligned_by: String = "src"
   @BeanProperty var prefix: String = ""
   @BeanProperty var file_type: String = ""
-  @BeanProperty var property_groups = new java.util.ArrayList[PropertyGroup]()
 
   override def equals(that: Any): Boolean = {
     that match {
@@ -250,8 +249,7 @@ class AdjList() {
         this.ordered == other.ordered &&
           this.aligned_by == other.aligned_by &&
           this.prefix == other.prefix &&
-          this.file_type == other.file_type &&
-          this.property_groups == other.property_groups
+          this.file_type == other.file_type
       case _ => false
     }
   }
@@ -288,14 +286,6 @@ class AdjList() {
     data.put("file_type", file_type)
     data.put("ordered", new java.lang.Boolean(ordered))
     data.put("aligned_by", aligned_by)
-    val property_group_num = property_groups.size()
-    if (property_group_num > 0) {
-      val property_group_maps = new java.util.ArrayList[Object]()
-      for (i <- 0 until property_group_num) {
-        property_group_maps.add(property_groups.get(i).toMap())
-      }
-      data.put("property_groups", property_group_maps)
-    }
     return data
   }
 }

--- a/spark/src/main/scala/com/alibaba/graphar/reader/EdgeReader.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/reader/EdgeReader.scala
@@ -234,7 +234,7 @@ class EdgeReader(
       vertex_chunk_index: Long,
       chunk_index: Long
   ): DataFrame = {
-    if (edgeInfo.containPropertyGroup(propertyGroup, adjListType) == false) {
+    if (edgeInfo.containPropertyGroup(propertyGroup) == false) {
       throw new IllegalArgumentException(
         "Edge info does not contain property group or adj list type."
       )
@@ -273,7 +273,7 @@ class EdgeReader(
       vertex_chunk_index: Long,
       addIndex: Boolean = true
   ): DataFrame = {
-    if (edgeInfo.containPropertyGroup(propertyGroup, adjListType) == false) {
+    if (edgeInfo.containPropertyGroup(propertyGroup) == false) {
       throw new IllegalArgumentException(
         "Edge info does not contain property group or adj list type."
       )
@@ -311,7 +311,7 @@ class EdgeReader(
       propertyGroup: PropertyGroup,
       addIndex: Boolean = true
   ): DataFrame = {
-    if (edgeInfo.containPropertyGroup(propertyGroup, adjListType) == false) {
+    if (edgeInfo.containPropertyGroup(propertyGroup) == false) {
       throw new IllegalArgumentException(
         "Edge info does not contain property group or adj list type."
       )
@@ -446,7 +446,7 @@ class EdgeReader(
       vertex_chunk_index: Long,
       addIndex: Boolean = true
   ): DataFrame = {
-    val property_groups = edgeInfo.getPropertyGroups(adjListType)
+    val property_groups = edgeInfo.getProperty_groups()
     return readMultipleEdgePropertyGroupsForVertexChunk(
       property_groups,
       vertex_chunk_index,
@@ -463,7 +463,7 @@ class EdgeReader(
    *   DataFrame tha contains all property groups chunks of edge.
    */
   def readAllEdgePropertyGroups(addIndex: Boolean = true): DataFrame = {
-    val property_groups = edgeInfo.getPropertyGroups(adjListType)
+    val property_groups = edgeInfo.getProperty_groups()
     return readMultipleEdgePropertyGroups(property_groups, addIndex)
   }
 
@@ -505,7 +505,7 @@ class EdgeReader(
    */
   def readEdges(addIndex: Boolean = true): DataFrame = {
     val adjList_df = readAllAdjList(false)
-    val property_groups = edgeInfo.getPropertyGroups(adjListType)
+    val property_groups = edgeInfo.getProperty_groups()
     val df = if (property_groups.size == 0) {
       adjList_df
     } else {

--- a/spark/src/main/scala/com/alibaba/graphar/util/Utils.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/util/Utils.scala
@@ -160,10 +160,13 @@ object Utils {
         cscAdjList.setOrdered(true)
         cscAdjList.setAligned_by("dst")
         cscAdjList.setFile_type(fileType)
+        edgeInfo.getAdj_lists().add(csrAdjList)
+        edgeInfo.getAdj_lists().add(cscAdjList)
+        edgeInfo.getProperty_groups().add(new PropertyGroup())
+        val propertyGroup = edgeInfo.getProperty_groups().get(0)
+        propertyGroup.setFile_type(fileType)
+        val properties = propertyGroup.getProperties()
         if (schema.length > 0) {
-          val propertyGroup = new PropertyGroup()
-          propertyGroup.setFile_type(fileType)
-          val properties = propertyGroup.getProperties()
           schema.foreach {
             case field => {
               val property = new Property()
@@ -174,11 +177,7 @@ object Utils {
               properties.add(property)
             }
           }
-          csrAdjList.getProperty_groups().add(propertyGroup)
-          cscAdjList.getProperty_groups().add(propertyGroup)
         }
-        edgeInfo.getAdj_lists().add(csrAdjList)
-        edgeInfo.getAdj_lists().add(cscAdjList)
         info.addEdgeInfo(edgeInfo)
         info.edges.add(edgeInfo.getConcatKey() + ".edge.yml")
       }

--- a/spark/src/main/scala/com/alibaba/graphar/util/Utils.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/util/Utils.scala
@@ -162,11 +162,11 @@ object Utils {
         cscAdjList.setFile_type(fileType)
         edgeInfo.getAdj_lists().add(csrAdjList)
         edgeInfo.getAdj_lists().add(cscAdjList)
-        edgeInfo.getProperty_groups().add(new PropertyGroup())
-        val propertyGroup = edgeInfo.getProperty_groups().get(0)
-        propertyGroup.setFile_type(fileType)
-        val properties = propertyGroup.getProperties()
         if (schema.length > 0) {
+          edgeInfo.getProperty_groups().add(new PropertyGroup())
+          val propertyGroup = edgeInfo.getProperty_groups().get(0)
+          propertyGroup.setFile_type(fileType)
+          val properties = propertyGroup.getProperties()
           schema.foreach {
             case field => {
               val property = new Property()

--- a/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
@@ -324,7 +324,7 @@ class EdgeWriter(
    *   property group
    */
   def writeEdgeProperties(propertyGroup: PropertyGroup): Unit = {
-    if (edgeInfo.containPropertyGroup(propertyGroup, adjListType) == false) {
+    if (edgeInfo.containPropertyGroup(propertyGroup) == false) {
       throw new IllegalArgumentException(
         "property group not contained in edge info."
       )
@@ -350,7 +350,7 @@ class EdgeWriter(
 
   /** Generate the chunks of all property groups from edge DataFrame. */
   def writeEdgeProperties(): Unit = {
-    val property_groups = edgeInfo.getPropertyGroups(adjListType)
+    val property_groups = edgeInfo.getProperty_groups()
     val it = property_groups.iterator
     while (it.hasNext()) {
       val property_group = it.next()

--- a/spark/src/test/scala/com/alibaba/graphar/ComputeExample.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/ComputeExample.scala
@@ -31,7 +31,7 @@ class ComputeExampleSuite extends AnyFunSuite {
 
   test("run cc using graphx") {
     // read vertex DataFrame
-    val file_path = "gar-test/ldbc_sample/parquet/"
+    val file_path = "gar-test/new/ldbc_sample/parquet/"
     val prefix = getClass.getClassLoader.getResource(file_path).getPath
     val vertex_yaml = getClass.getClassLoader
       .getResource(file_path + "person.vertex.yml")

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -371,11 +371,6 @@ class GraphInfoSuite extends AnyFunSuite {
     assertThrows[IllegalArgumentException](
       edge_info.getAdjListFileType(AdjListType.unordered_by_source)
     )
-    assert(
-      edge_info.containPropertyGroup(
-        property_group
-      ) == false
-    )
     assertThrows[IllegalArgumentException](
       edge_info.getVerticesNumFilePath(AdjListType.unordered_by_source)
     )

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -32,7 +32,9 @@ class GraphInfoSuite extends AnyFunSuite {
       .getResource("gar-test/new/ldbc_sample/csv/ldbc_sample.graph.yml")
       .getPath
     val prefix =
-      getClass.getClassLoader.getResource("gar-test/new/ldbc_sample/csv/").getPath
+      getClass.getClassLoader
+        .getResource("gar-test/new/ldbc_sample/csv/")
+        .getPath
     val graph_info = GraphInfo.loadGraphInfo(yaml_path, spark)
 
     val vertex_info = graph_info.getVertexInfo("person")

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -153,7 +153,7 @@ class GraphInfoSuite extends AnyFunSuite {
         AdjListType.ordered_by_source
       ) == FileType.CSV
     )
-    assert(edge_info.getPropertyGroups(AdjListType.ordered_by_source).size == 1)
+    assert(edge_info.getProperty_groups().size == 1)
     assert(
       edge_info.getVerticesNumFilePath(
         AdjListType.ordered_by_source
@@ -219,11 +219,10 @@ class GraphInfoSuite extends AnyFunSuite {
       ) == "edge/person_knows_person/ordered_by_source/offset/"
     )
     val property_group =
-      edge_info.getPropertyGroups(AdjListType.ordered_by_source).get(0)
+      edge_info.getProperty_groups().get(0)
     assert(
       edge_info.containPropertyGroup(
-        property_group,
-        AdjListType.ordered_by_source
+        property_group
       )
     )
     val property = property_group.getProperties.get(0)
@@ -231,8 +230,7 @@ class GraphInfoSuite extends AnyFunSuite {
     assert(edge_info.containProperty(property_name))
     assert(
       edge_info.getPropertyGroup(
-        property_name,
-        AdjListType.ordered_by_source
+        property_name
       ) == property_group
     )
     assert(
@@ -271,7 +269,7 @@ class GraphInfoSuite extends AnyFunSuite {
     assert(
       edge_info.getAdjListFileType(AdjListType.ordered_by_dest) == FileType.CSV
     )
-    assert(edge_info.getPropertyGroups(AdjListType.ordered_by_dest).size == 1)
+    assert(edge_info.getProperty_groups().size == 1)
     assert(
       edge_info.getAdjListFilePath(
         0,
@@ -321,11 +319,10 @@ class GraphInfoSuite extends AnyFunSuite {
       ) == "edge/person_knows_person/ordered_by_dest/offset/"
     )
     val property_group_2 =
-      edge_info.getPropertyGroups(AdjListType.ordered_by_dest).get(0)
+      edge_info.getProperty_groups().get(0)
     assert(
       edge_info.containPropertyGroup(
-        property_group_2,
-        AdjListType.ordered_by_dest
+        property_group_2
       )
     )
     val property_2 = property_group_2.getProperties.get(0)
@@ -333,8 +330,7 @@ class GraphInfoSuite extends AnyFunSuite {
     assert(edge_info.containProperty(property_name_2))
     assert(
       edge_info.getPropertyGroup(
-        property_name_2,
-        AdjListType.ordered_by_dest
+        property_name_2
       ) == property_group_2
     )
     assert(
@@ -373,13 +369,9 @@ class GraphInfoSuite extends AnyFunSuite {
     assertThrows[IllegalArgumentException](
       edge_info.getAdjListFileType(AdjListType.unordered_by_source)
     )
-    assertThrows[IllegalArgumentException](
-      edge_info.getPropertyGroups(AdjListType.unordered_by_source)
-    )
     assert(
       edge_info.containPropertyGroup(
-        property_group,
-        AdjListType.unordered_by_source
+        property_group
       ) == false
     )
     assertThrows[IllegalArgumentException](
@@ -407,7 +399,7 @@ class GraphInfoSuite extends AnyFunSuite {
     )
     assert(edge_info.containProperty("not_exist") == false)
     assertThrows[IllegalArgumentException](
-      edge_info.getPropertyGroup("not_exist", AdjListType.ordered_by_source)
+      edge_info.getPropertyGroup("not_exist")
     )
     assertThrows[IllegalArgumentException](
       edge_info.getPropertyType("not_exist")
@@ -444,14 +436,6 @@ class GraphInfoSuite extends AnyFunSuite {
     assert(pg1 == pg2)
     val al1 = new AdjList()
     val al2 = new AdjList()
-    assert(al1 == al2)
-    al1.setProperty_groups(
-      new java.util.ArrayList[PropertyGroup](java.util.Arrays.asList(pg1))
-    )
-    assert(al1 != al2)
-    al2.setProperty_groups(
-      new java.util.ArrayList[PropertyGroup](java.util.Arrays.asList(pg2))
-    )
     assert(al1 == al2)
   }
 }

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -29,10 +29,10 @@ class GraphInfoSuite extends AnyFunSuite {
   test("load graph info") {
     // read graph yaml
     val yaml_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/csv/ldbc_sample.graph.yml")
+      .getResource("gar-test/new/ldbc_sample/csv/ldbc_sample.graph.yml")
       .getPath
     val prefix =
-      getClass.getClassLoader.getResource("gar-test/ldbc_sample/csv/").getPath
+      getClass.getClassLoader.getResource("gar-test/new/ldbc_sample/csv/").getPath
     val graph_info = GraphInfo.loadGraphInfo(yaml_path, spark)
 
     val vertex_info = graph_info.getVertexInfo("person")

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphInfo.scala
@@ -127,7 +127,7 @@ class GraphInfoSuite extends AnyFunSuite {
 
   test("load edge info") {
     val yaml_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/csv/person_knows_person.edge.yml")
+      .getResource("gar-test/new/ldbc_sample/csv/person_knows_person.edge.yml")
       .getPath
     val edge_info = EdgeInfo.loadEdgeInfo(yaml_path, spark)
 

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphReader.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphReader.scala
@@ -31,7 +31,7 @@ class TestGraphReaderSuite extends AnyFunSuite {
   test("read graphs by yaml paths") {
     // conduct reading
     val graph_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/parquet/ldbc_sample.graph.yml")
+      .getResource("gar-test/new/ldbc_sample/parquet/ldbc_sample.graph.yml")
       .getPath
     val vertex_edge_df_pair = GraphReader.read(graph_path, spark)
     val vertex_dataframes = vertex_edge_df_pair._1
@@ -54,7 +54,7 @@ class TestGraphReaderSuite extends AnyFunSuite {
   test("read graphs by graph infos") {
     // load graph info
     val path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/parquet/ldbc_sample.graph.yml")
+      .getResource("gar-test/new/ldbc_sample/parquet/ldbc_sample.graph.yml")
       .getPath
     val graph_info = GraphInfo.loadGraphInfo(path, spark)
 

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
@@ -35,7 +35,7 @@ class TestGraphTransformerSuite extends AnyFunSuite {
       .getResource("gar-test/new/ldbc_sample/parquet/ldbc_sample.graph.yml")
       .getPath
     val dest_path = getClass.getClassLoader
-      .getResource("gar-test/transformer/ldbc_sample_new.graph.yml")
+      .getResource("gar-test/transformer/ldbc_sample.graph.yml")
       .getPath
     GraphTransformer.transform(source_path, dest_path, spark)
 
@@ -77,7 +77,7 @@ class TestGraphTransformerSuite extends AnyFunSuite {
 
     // load dest graph info
     val dest_path = getClass.getClassLoader
-      .getResource("gar-test/transformer/ldbc_sample_new.graph.yml")
+      .getResource("gar-test/transformer/ldbc_sample.graph.yml")
       .getPath
     val dest_graph_info = GraphInfo.loadGraphInfo(dest_path, spark)
 

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
@@ -32,7 +32,7 @@ class TestGraphTransformerSuite extends AnyFunSuite {
   test("transform graphs by yaml paths") {
     // conduct transformation
     val source_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/parquet/ldbc_sample.graph.yml")
+      .getResource("gar-test/new/ldbc_sample/parquet/ldbc_sample.graph.yml")
       .getPath
     val dest_path = getClass.getClassLoader
       .getResource("gar-test/transformer/ldbc_sample.graph.yml")

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
@@ -71,7 +71,7 @@ class TestGraphTransformerSuite extends AnyFunSuite {
   test("transform graphs by graph infos") {
     // load source graph info
     val source_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/parquet/ldbc_sample.graph.yml")
+      .getResource("gar-test/new/ldbc_sample/parquet/ldbc_sample.graph.yml")
       .getPath
     val source_graph_info = GraphInfo.loadGraphInfo(source_path, spark)
 

--- a/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestGraphTransformer.scala
@@ -35,7 +35,7 @@ class TestGraphTransformerSuite extends AnyFunSuite {
       .getResource("gar-test/new/ldbc_sample/parquet/ldbc_sample.graph.yml")
       .getPath
     val dest_path = getClass.getClassLoader
-      .getResource("gar-test/transformer/ldbc_sample.graph.yml")
+      .getResource("gar-test/transformer/ldbc_sample_new.graph.yml")
       .getPath
     GraphTransformer.transform(source_path, dest_path, spark)
 
@@ -77,7 +77,7 @@ class TestGraphTransformerSuite extends AnyFunSuite {
 
     // load dest graph info
     val dest_path = getClass.getClassLoader
-      .getResource("gar-test/transformer/ldbc_sample.graph.yml")
+      .getResource("gar-test/transformer/ldbc_sample_new.graph.yml")
       .getPath
     val dest_graph_info = GraphInfo.loadGraphInfo(dest_path, spark)
 

--- a/spark/src/test/scala/com/alibaba/graphar/TestReader.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestReader.scala
@@ -112,7 +112,7 @@ class ReaderSuite extends AnyFunSuite {
 
   test("read vertex chunks") {
     // construct the vertex information
-    val file_path = "gar-test/ldbc_sample/parquet/"
+    val file_path = "gar-test/new/ldbc_sample/parquet/"
     val prefix = getClass.getClassLoader.getResource(file_path).getPath
     val vertex_yaml = getClass.getClassLoader
       .getResource(file_path + "person.vertex.yml")
@@ -210,7 +210,7 @@ class ReaderSuite extends AnyFunSuite {
 
   test("read edge chunks") {
     // construct the edge information
-    val file_path = "gar-test/ldbc_sample/csv/"
+    val file_path = "gar-test/new/ldbc_sample/csv/"
     val prefix = getClass.getClassLoader.getResource(file_path).getPath
     val edge_yaml = getClass.getClassLoader
       .getResource(file_path + "person_knows_person.edge.yml")

--- a/spark/src/test/scala/com/alibaba/graphar/TestReader.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestReader.scala
@@ -245,7 +245,7 @@ class ReaderSuite extends AnyFunSuite {
 
     // test reading a single property group
     val property_group =
-      edge_info.getPropertyGroup("creationDate", adj_list_type)
+      edge_info.getPropertyGroup("creationDate")
     val single_property_df = reader.readEdgePropertyChunk(property_group, 2, 0)
     assert(single_property_df.columns.size == 1)
     assert(single_property_df.count() == 1024)

--- a/spark/src/test/scala/com/alibaba/graphar/TestWriter.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestWriter.scala
@@ -46,7 +46,7 @@ class WriterSuite extends AnyFunSuite {
 
     // read vertex yaml
     val vertex_yaml_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/parquet/person.vertex.yml")
+      .getResource("gar-test/new/ldbc_sample/parquet/person.vertex.yml")
       .getPath
     val vertex_info = VertexInfo.loadVertexInfo(vertex_yaml_path, spark)
 
@@ -106,7 +106,7 @@ class WriterSuite extends AnyFunSuite {
 
     // read edge yaml
     val edge_yaml_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/csv/person_knows_person.edge.yml")
+      .getResource("gar-test/new/ldbc_sample/csv/person_knows_person.edge.yml")
       .getPath
     val edge_info = EdgeInfo.loadEdgeInfo(edge_yaml_path, spark)
     val adj_list_type = AdjListType.ordered_by_source
@@ -245,13 +245,13 @@ class WriterSuite extends AnyFunSuite {
 
     // read vertex yaml
     val vertex_yaml_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/csv/person.vertex.yml")
+      .getResource("gar-test/new/ldbc_sample/csv/person.vertex.yml")
       .getPath
     val vertex_info = VertexInfo.loadVertexInfo(vertex_yaml_path, spark)
 
     // read edge yaml
     val edge_yaml_path = getClass.getClassLoader
-      .getResource("gar-test/ldbc_sample/csv/person_knows_person.edge.yml")
+      .getResource("gar-test/new/ldbc_sample/csv/person_knows_person.edge.yml")
       .getPath
     val edge_info = EdgeInfo.loadEdgeInfo(edge_yaml_path, spark)
     val vertex_chunk_size = edge_info.getSrc_chunk_size()

--- a/spark/src/test/scala/com/alibaba/graphar/TestWriter.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TestWriter.scala
@@ -169,7 +169,7 @@ class WriterSuite extends AnyFunSuite {
 
     // test write property group
     val property_group =
-      edge_info.getPropertyGroup("creationDate", adj_list_type)
+      edge_info.getPropertyGroup("creationDate")
     writer.writeEdgeProperties(property_group)
 
     val property_group_path_pattern = new Path(
@@ -334,7 +334,7 @@ class WriterSuite extends AnyFunSuite {
 
     // test write property group
     val property_group =
-      edge_info.getPropertyGroup("creationDate", adj_list_type)
+      edge_info.getPropertyGroup("creationDate")
     writer.writeEdgeProperties(property_group)
     val property_group_path_pattern = new Path(
       prefix + edge_info.getPropertyGroupPathPrefix(

--- a/spark/src/test/scala/com/alibaba/graphar/TransformExample.scala
+++ b/spark/src/test/scala/com/alibaba/graphar/TransformExample.scala
@@ -32,7 +32,7 @@ class TransformExampleSuite extends AnyFunSuite {
 
   test("transform file type") {
     // read from orc files
-    val file_path = "gar-test/ldbc_sample/orc/"
+    val file_path = "gar-test/new/ldbc_sample/orc/"
     val prefix = getClass.getClassLoader.getResource(file_path).getPath
     val vertex_yaml = getClass.getClassLoader
       .getResource(file_path + "person.vertex.yml")
@@ -45,7 +45,7 @@ class TransformExampleSuite extends AnyFunSuite {
     assert(vertex_df_with_index.count() == vertices_num)
 
     // write to parquet files
-    val output_file_path = "gar-test/ldbc_sample/parquet/"
+    val output_file_path = "gar-test/new/ldbc_sample/parquet/"
     val output_prefix: String = "/tmp/example/"
     val output_vertex_yaml = getClass.getClassLoader
       .getResource(output_file_path + "person.vertex.yml")
@@ -69,7 +69,7 @@ class TransformExampleSuite extends AnyFunSuite {
   }
 
   test("transform adjList type") {
-    val file_path = "gar-test/ldbc_sample/parquet/"
+    val file_path = "gar-test/new/ldbc_sample/parquet/"
     val prefix = getClass.getClassLoader.getResource(file_path).getPath
     // get vertex num
     val vertex_yaml = getClass.getClassLoader


### PR DESCRIPTION
## Proposed changes
Update the graphar-spark implementation of EdgeInfo to the latest design that extract property group from adj list.

sync the update to graphar-pyspark too.

the edge info  from
```
src_label: person
edge_label: created
dst_label: software
chunk_size: 2
src_chunk_size: 2
dst_chunk_size: 10
directed: true
prefix: edge/person_created_software/
adj_lists:
  - ordered: true
    aligned_by: src
    prefix: ordered_by_source/
    file_type: csv
    property_groups:
      - prefix: weight/
        file_type: csv
        properties:
          - name: weight
            data_type: double
            is_primary: false
```
change to
```
src_label: person
edge_label: created
dst_label: software
chunk_size: 2
src_chunk_size: 2
dst_chunk_size: 10
directed: true
prefix: edge/person_created_software/
adj_lists:
  - ordered: true
    aligned_by: src
    prefix: ordered_by_source/
    file_type: csv
property_groups:
  - prefix: weight/
    file_type: csv
    properties:
      - name: weight
        data_type: double
        is_primary: false
version: gar/v1
```


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
close #315 
