### PR TITLE
[Feat][Spark] Memory tuning for GraphAr spark with persist and storage level

### DIFF
--- a/spark/src/main/java/com/alibaba/graphar/GeneralParams.java
+++ b/spark/src/main/java/com/alibaba/graphar/GeneralParams.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.graphar;
 
+import org.apache.spark.storage.StorageLevel;
+
 /** General constant parameters for graphar. */
 public class GeneralParams {
     // column name
@@ -33,4 +35,5 @@ public class GeneralParams {
     public static final Long defaultEdgeChunkSize = 4194304L; // 2^22
     public static final String defaultFileType = "parquet";
     public static final String defaultVersion = "v1";
+    public static final StorageLevel defaultStorageLevel = StorageLevel.MEMORY_AND_DISK_SER();
 }

--- a/spark/src/main/scala/com/alibaba/graphar/graph/GraphTransformer.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/graph/GraphTransformer.scala
@@ -16,7 +16,13 @@
 
 package com.alibaba.graphar.graph
 
-import com.alibaba.graphar.{AdjListType, GraphInfo, VertexInfo, EdgeInfo}
+import com.alibaba.graphar.{
+  AdjListType,
+  GraphInfo,
+  VertexInfo,
+  EdgeInfo,
+  GeneralParams
+}
 import com.alibaba.graphar.reader.{VertexReader, EdgeReader}
 import com.alibaba.graphar.writer.{VertexWriter, EdgeWriter}
 

--- a/spark/src/main/scala/com/alibaba/graphar/graph/GraphTransformer.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/graph/GraphTransformer.scala
@@ -67,9 +67,11 @@ object GraphTransformer {
       // read vertex chunks from the source graph
       val reader = new VertexReader(source_prefix, source_vertex_info, spark)
       val df = reader.readAllVertexPropertyGroups()
+      df.persist(GeneralParams.defaultStorageLevel)
       // write vertex chunks for the dest graph
       val writer = new VertexWriter(dest_prefix, dest_vertex_info, df)
       writer.writeVertexProperties()
+      df.unpersist()
     }
   }
 
@@ -138,6 +140,7 @@ object GraphTransformer {
           )
           df = reader.readEdges(false)
           has_loaded = true
+          df.persist(GeneralParams.defaultStorageLevel)
         }
 
         // read vertices number
@@ -167,6 +170,7 @@ object GraphTransformer {
           df
         )
         writer.writeEdges()
+        df.unpersist()
       }
     }
   }

--- a/spark/src/main/scala/com/alibaba/graphar/graph/GraphWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/graph/GraphWriter.scala
@@ -87,11 +87,17 @@ class GraphWriter() {
     vertexInfos.foreach {
       case (label, vertexInfo) => {
         val primaryKey = primaryKeys(label)
-        vertices(label).persist(GeneralParams.defaultStorageLevel)  // cache the vertex DataFrame
+        vertices(label).persist(
+          GeneralParams.defaultStorageLevel
+        ) // cache the vertex DataFrame
         val df_and_mapping = IndexGenerator
           .generateVertexIndexColumnAndIndexMapping(vertices(label), primaryKey)
-        df_and_mapping._1.persist(GeneralParams.defaultStorageLevel) // cache the vertex DataFrame with index
-        df_and_mapping._2.persist(GeneralParams.defaultStorageLevel) // cache the index mapping DataFrame
+        df_and_mapping._1.persist(
+          GeneralParams.defaultStorageLevel
+        ) // cache the vertex DataFrame with index
+        df_and_mapping._2.persist(
+          GeneralParams.defaultStorageLevel
+        ) // cache the index mapping DataFrame
         vertices(label).unpersist() // unpersist the vertex DataFrame
         val df_with_index = df_and_mapping._1
         indexMappings += label -> df_and_mapping._2
@@ -121,7 +127,9 @@ class GraphWriter() {
             src_vertex_index_mapping,
             dst_vertex_index_mapping
           )
-        edge_df_with_index.persist(GeneralParams.defaultStorageLevel) // cache the edge DataFrame with index
+        edge_df_with_index.persist(
+          GeneralParams.defaultStorageLevel
+        ) // cache the edge DataFrame with index
 
         val adj_lists = edgeInfo.getAdj_lists
         val adj_list_it = adj_lists.iterator

--- a/spark/src/main/scala/com/alibaba/graphar/util/FileSystem.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/util/FileSystem.scala
@@ -55,8 +55,8 @@ object FileSystem {
     // TODO: Make the hard-code setting to configurable
     spark.conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
     spark.conf.set("parquet.enable.summary-metadata", "false")
-    spark.conf.set("spark.sql.orc.compression.codec", "zstd")
-    spark.conf.set("spark.sql.parquet.compression.codec", "zstd")
+    spark.conf.set("spark.sql.orc.compression.codec", "snappy")
+    spark.conf.set("spark.sql.parquet.compression.codec", "snappy")
     // first check the outputPrefix exists, if not, create it
     val path = new Path(outputPrefix)
     val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)

--- a/spark/src/main/scala/com/alibaba/graphar/util/FileSystem.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/util/FileSystem.scala
@@ -55,8 +55,8 @@ object FileSystem {
     // TODO: Make the hard-code setting to configurable
     spark.conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
     spark.conf.set("parquet.enable.summary-metadata", "false")
-    spark.conf.set("spark.sql.orc.compression.codec", "snappy")
-    spark.conf.set("spark.sql.parquet.compression.codec", "snappy")
+    spark.conf.set("spark.sql.orc.compression.codec", "zstd")
+    spark.conf.set("spark.sql.parquet.compression.codec", "zstd")
     // first check the outputPrefix exists, if not, create it
     val path = new Path(outputPrefix)
     val fs = path.getFileSystem(spark.sparkContext.hadoopConfiguration)

--- a/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/writer/EdgeWriter.scala
@@ -222,7 +222,7 @@ class EdgeWriter(
   private val spark: SparkSession = edgeDf.sparkSession
   validate()
   writeVertexNum()
-  
+
   edgeDf.persist(GeneralParams.defaultStorageLevel)
 
   // validate data and info
@@ -266,7 +266,7 @@ class EdgeWriter(
       adjListType,
       vertexNum
     )
-  
+
   // write out the edge number
   private def writeEdgeNum(): Unit = {
     val vertexChunkSize: Long = if (

--- a/spark/src/main/scala/com/alibaba/graphar/writer/VertexWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/writer/VertexWriter.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{LongType, StructField}
-import org.apache.spark.storage.StorageLevel
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -75,7 +74,7 @@ class VertexWriter(
     numVertices: Long = -1
 ) {
   private val spark = vertexDf.sparkSession
-  vertexDf.persist(StorageLevel.MEMORY_AND_DISK_SER) // cache the vertex DataFrame
+  vertexDf.persist(GeneralParams.defaultStorageLevel) // cache the vertex DataFrame
   validate()
   private val vertexNum: Long =
     if (numVertices < 0) vertexDf.count else numVertices
@@ -87,7 +86,7 @@ class VertexWriter(
     vertexNum
   )
   vertexDf.unpersist() // unpersist the vertex DataFrame
-  chunks.persist(StorageLevel.MEMORY_AND_DISK_SER)
+  chunks.persist(GeneralParams.defaultStorageLevel)
 
   private def validate(): Unit = {
     // check if vertex DataFrame contains the index_filed
@@ -152,4 +151,9 @@ class VertexWriter(
       writeVertexProperties(property_group)
     }
   }
+
+  override def finalize(): Unit = {
+    chunks.unpersist()
+  }
+
 }

--- a/spark/src/main/scala/com/alibaba/graphar/writer/VertexWriter.scala
+++ b/spark/src/main/scala/com/alibaba/graphar/writer/VertexWriter.scala
@@ -74,7 +74,9 @@ class VertexWriter(
     numVertices: Long = -1
 ) {
   private val spark = vertexDf.sparkSession
-  vertexDf.persist(GeneralParams.defaultStorageLevel) // cache the vertex DataFrame
+  vertexDf.persist(
+    GeneralParams.defaultStorageLevel
+  ) // cache the vertex DataFrame
   validate()
   private val vertexNum: Long =
     if (numVertices < 0) vertexDf.count else numVertices


### PR DESCRIPTION
## Proposed changes
This change tuning the memory usage of GraphAr spark with
- Persist the DataFrame and RDD that frequently used and unpersist them when they are not used anymore.
- Use `MEMORY_AND_DISK_SER` as persist storage level for reduce the memory usage

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
related #324 
close #322 