### PR TITLE
[Feat][Format][C++] Support nullable key for property in meta-data

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /examples/*/build/
+/cmake-build-debug
 
 apidoc/html
 apidoc/xml

--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -46,7 +46,8 @@ class Property {
 
 static bool operator==(const Property& lhs, const Property& rhs) {
   return (lhs.name == rhs.name) && (lhs.type == rhs.type) &&
-         (lhs.is_primary == rhs.is_primary) && (lhs.is_nullable == rhs.is_nullable);
+         (lhs.is_primary == rhs.is_primary) &&
+         (lhs.is_nullable == rhs.is_nullable);
 }
 
 /**

--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -33,16 +33,20 @@ class Property {
   std::string name;                // property name
   std::shared_ptr<DataType> type;  // property data type
   bool is_primary;                 // primary key tag
+  bool is_nullable;                // nullable tag for non-primary key
 
   explicit Property(const std::string& name,
                     const std::shared_ptr<DataType>& type = nullptr,
-                    bool is_primary = false)
-      : name(name), type(type), is_primary(is_primary) {}
+                    bool is_primary = false, bool is_nullable = true)
+      : name(name),
+        type(type),
+        is_primary(is_primary),
+        is_nullable(!is_primary && is_nullable) {}
 };
 
 static bool operator==(const Property& lhs, const Property& rhs) {
   return (lhs.name == rhs.name) && (lhs.type == rhs.type) &&
-         (lhs.is_primary == rhs.is_primary);
+         (lhs.is_primary == rhs.is_primary) && (lhs.is_nullable == rhs.is_nullable);
 }
 
 /**
@@ -270,6 +274,14 @@ class VertexInfo {
    * @return True if the property is a primary key, False otherwise.
    */
   bool IsPrimaryKey(const std::string& property_name) const;
+
+  /**
+   * Returns whether the specified property is a nullable key.
+   *
+   * @param property_name The name of the property.
+   * @return True if the property is a nullable key, False otherwise.
+   */
+  bool IsNullableKey(const std::string& property_name) const;
 
   /**
    * Returns whether the vertex info contains the specified property group.
@@ -596,10 +608,17 @@ class EdgeInfo {
    * Returns whether the specified property is a primary key.
    *
    * @param property_name The name of the property.
-   * @return A Result object containing a bool indicating whether the property
-   * is a primary key, or a KeyError Status object if the property is not found.
+   * @return True if the property is a primary key, False otherwise.
    */
   bool IsPrimaryKey(const std::string& property_name) const;
+
+  /**
+   * Returns whether the specified property is a nullable key.
+   *
+   * @param property_name The name of the property.
+   * @return True if the property is a nullable key, False otherwise.
+   */
+  bool IsNullableKey(const std::string& property_name) const;
 
   /**
    * Saves the edge info to a YAML file.

--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -293,12 +293,12 @@ bool VertexInfo::IsPrimaryKey(const std::string& property_name) const {
   return it->second;
 }
 
-bool VertexInfo::IsNullableKey(const std::string &property_name) const {
-    auto it = impl_->property_name_to_nullable_.find(property_name);
-    if (it == impl_->property_name_to_nullable_.end()) {
-        return false;
-    }
-    return it->second;
+bool VertexInfo::IsNullableKey(const std::string& property_name) const {
+  auto it = impl_->property_name_to_nullable_.find(property_name);
+  if (it == impl_->property_name_to_nullable_.end()) {
+    return false;
+  }
+  return it->second;
 }
 
 bool VertexInfo::HasProperty(const std::string& property_name) const {
@@ -392,8 +392,10 @@ Result<std::shared_ptr<VertexInfo>> VertexInfo::Load(
         auto property_type =
             DataType::TypeNameToDataType(p_node["data_type"].As<std::string>());
         bool is_primary = p_node["is_primary"].As<bool>();
-        bool is_nullable = p_node["is_nullable"].IsNone() || p_node["is_nullable"].As<bool>();
-        property_vec.emplace_back(property_name, property_type, is_primary, is_nullable);
+        bool is_nullable =
+            p_node["is_nullable"].IsNone() || p_node["is_nullable"].As<bool>();
+        property_vec.emplace_back(property_name, property_type, is_primary,
+                                  is_nullable);
       }
       property_groups.push_back(
           std::make_shared<PropertyGroup>(property_vec, file_type, pg_prefix));
@@ -720,12 +722,12 @@ bool EdgeInfo::IsPrimaryKey(const std::string& property_name) const {
   return it->second;
 }
 
-bool EdgeInfo::IsNullableKey(const std::string &property_name) const {
-    auto it = impl_->property_name_to_nullable_.find(property_name);
-    if (it == impl_->property_name_to_nullable_.end()) {
-        return false;
-    }
-    return it->second;
+bool EdgeInfo::IsNullableKey(const std::string& property_name) const {
+  auto it = impl_->property_name_to_nullable_.find(property_name);
+  if (it == impl_->property_name_to_nullable_.end()) {
+    return false;
+  }
+  return it->second;
 }
 
 Result<std::shared_ptr<EdgeInfo>> EdgeInfo::AddAdjacentList(
@@ -839,8 +841,10 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
         auto property_type =
             DataType::TypeNameToDataType(p_node["data_type"].As<std::string>());
         bool is_primary = p_node["is_primary"].As<bool>();
-        bool is_nullable = p_node["is_nullable"].IsNone() || p_node["is_nullable"].As<bool>();
-        property_vec.emplace_back(property_name, property_type, is_primary, is_nullable);
+        bool is_nullable =
+            p_node["is_nullable"].IsNone() || p_node["is_nullable"].As<bool>();
+        property_vec.emplace_back(property_name, property_type, is_primary,
+                                  is_nullable);
       }
       property_groups.push_back(
           std::make_shared<PropertyGroup>(property_vec, file_type, pg_prefix));

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -71,7 +71,9 @@ TEST_CASE("Property") {
   REQUIRE(p0.name == "p0");
   REQUIRE(p0.type->ToTypeName() == int32()->ToTypeName());
   REQUIRE(p0.is_primary == true);
+  REQUIRE(p0.is_nullable == false);
   REQUIRE(p1.is_primary == false);
+  REQUIRE(p1.is_nullable == true);
 }
 
 TEST_CASE("PropertyGroup") {
@@ -95,6 +97,7 @@ TEST_CASE("PropertyGroup") {
     REQUIRE(p.name == "p0");
     REQUIRE(p.type->ToTypeName() == int32()->ToTypeName());
     REQUIRE(p.is_primary == true);
+    REQUIRE(p.is_nullable == false);
   }
 
   SECTION("FileType") {
@@ -199,6 +202,8 @@ TEST_CASE("VertexInfo") {
             int32()->ToTypeName());
     REQUIRE(vertex_info->IsPrimaryKey("p0") == true);
     REQUIRE(vertex_info->IsPrimaryKey("p1") == false);
+    REQUIRE(vertex_info->IsNullableKey("p0") == false);
+    REQUIRE(vertex_info->IsNullableKey("p1") == true);
     REQUIRE(vertex_info->HasProperty("not_exist") == false);
     REQUIRE(vertex_info->IsPrimaryKey("not_exist") == false);
     REQUIRE(vertex_info->HasPropertyGroup(nullptr) == false);
@@ -242,9 +247,11 @@ property_groups:
     prefix: p0_p1/
     properties: 
       - data_type: int32
+        is_nullable: false
         is_primary: true
         name: p0
       - data_type: string
+        is_nullable: true
         is_primary: false
         name: p1
 version: gar/v1
@@ -269,6 +276,7 @@ version: gar/v1
     REQUIRE(extend_info->GetPropertyType("p2").value()->ToTypeName() ==
             int32()->ToTypeName());
     REQUIRE(extend_info->IsPrimaryKey("p2") == false);
+    REQUIRE(extend_info->IsNullableKey("p2") == true);
     auto extend_info2 = extend_info->AddPropertyGroup(pg2);
     REQUIRE(!extend_info2.status().ok());
   }
@@ -327,8 +335,11 @@ TEST_CASE("EdgeInfo") {
             int32()->ToTypeName());
     REQUIRE(edge_info->IsPrimaryKey("p0") == true);
     REQUIRE(edge_info->IsPrimaryKey("p1") == false);
+    REQUIRE(edge_info->IsNullableKey("p0") == false);
+    REQUIRE(edge_info->IsNullableKey("p1") == true);
     REQUIRE(edge_info->HasProperty("not_exist") == false);
     REQUIRE(edge_info->IsPrimaryKey("not_exist") == false);
+    REQUIRE(edge_info->IsNullableKey("not_exist") == false);
     REQUIRE(edge_info->HasPropertyGroup(nullptr) == false);
   }
 
@@ -410,9 +421,11 @@ property_groups:
     prefix: p0_p1/
     properties: 
       - data_type: int32
+        is_nullable: false
         is_primary: true
         name: p0
       - data_type: string
+        is_nullable: true
         is_primary: false
         name: p1
 src_chunk_size: 100
@@ -601,17 +614,21 @@ property_groups:
       - name: id
         data_type: int64
         is_primary: true
+        is_nullable: false
     file_type: parquet
   - properties:
       - name: firstName
         data_type: string
         is_primary: false
+        is_nullable: true
       - name: lastName
         data_type: string
         is_primary: false
+        is_nullable: true
       - name: gender
         data_type: string
         is_primary: false
+        is_nullable: true
     file_type: parquet
 version: gar/v1
 )";
@@ -639,6 +656,7 @@ property_groups:
       - name: creationDate
         data_type: string
         is_primary: false
+        is_nullable: true
 version: gar/v1
 )";
   std::string graph_info_yaml = R"(name: ldbc_sample

--- a/docs/file-format.rst
+++ b/docs/file-format.rst
@@ -124,7 +124,7 @@ A vertex information file which named "<label>.vertex.yml" defines a single grou
 - the vertex label;
 - the vertex chunk size;
 - the relative path for vertex data files;
-- the property groups attached: each property group has its own file type and the prefix for the path of its data files, it also lists all properties in this group, with every property containing its own name, data type and flagging of whether it is the primary key or not;
+- the property groups attached: each property group has its own file type and the prefix for the path of its data files, it also lists all properties in this group, with every property containing its own name, data type, flagging of whether it is the primary key or not and flagging of whether it is nullable or not for non-primary key properties;
 - the version of GraphAr.
 
 An edge information file which named "<source label>_<edge label>_<destination label>.edge.yml" defines a single group of edges with specific label for source vertex, destination vertex and the edge. It describes the meta information for these edges, includes:


### PR DESCRIPTION
## Proposed changes

When property is not primary key and the `is_nullable` field is not exist, it well be set as nullable by default.

When property is primary, the `is_nullable` field will be ignored.

Progress:
- [x] C++ source code
- [x] test
- [ ] doc

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Related issue #351 

