### PR TITLE
[BugFix][C++] Fix bug: PropertyGroup with empty properties make VertexInfo/EdgeInfo dumps failed

### DIFF
--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -187,6 +187,8 @@ class VertexInfo {
                       const std::string& prefix = "",
                       std::shared_ptr<const InfoVersion> version = nullptr);
 
+  ~VertexInfo();
+
   /**
    * Adds a property group to the vertex info and returns a new VertexInfo
    *
@@ -401,6 +403,8 @@ class EdgeInfo {
                     const PropertyGroupVector& property_groups,
                     const std::string& prefix = "",
                     std::shared_ptr<const InfoVersion> version = nullptr);
+
+  ~EdgeInfo();
 
   /**
    * Add an adjacency list information to the edge info and returns a new
@@ -698,6 +702,8 @@ class GraphInfo {
       EdgeInfoVector edge_infos, const std::string& prefix = "./",
       std::shared_ptr<const InfoVersion> version = nullptr,
       const std::unordered_map<std::string, std::string>& extra_info = {});
+
+  ~GraphInfo();
 
   /**
    * @brief Loads the input file as a `GraphInfo` instance.

--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -199,6 +199,9 @@ class VertexInfo::Impl {
     }
     for (size_t i = 0; i < property_groups_.size(); i++) {
       const auto& pg = property_groups_[i];
+      if (!pg) {
+        continue;
+      }
       for (const auto& p : pg->GetProperties()) {
         property_name_to_index_.emplace(p.name, i);
         property_name_to_primary_.emplace(p.name, p.is_primary);
@@ -249,6 +252,8 @@ VertexInfo::VertexInfo(const std::string& label, IdType chunk_size,
                        const std::string& prefix,
                        std::shared_ptr<const InfoVersion> version)
     : impl_(new Impl(label, chunk_size, prefix, property_groups, version)) {}
+
+VertexInfo::~VertexInfo() = default;
 
 const std::string& VertexInfo::GetLabel() const { return impl_->label_; }
 
@@ -500,11 +505,18 @@ class EdgeInfo::Impl {
                 REGULAR_SEPARATOR + dst_label_ + "/";  // default prefix
     }
     for (size_t i = 0; i < adjacent_lists_.size(); i++) {
+      if (!adjacent_lists_[i]) {
+        continue;
+      }
+
       auto adj_list_type = adjacent_lists_[i]->GetType();
       adjacent_list_type_to_index_[adj_list_type] = i;
     }
     for (size_t i = 0; i < property_groups_.size(); i++) {
       const auto& pg = property_groups_[i];
+      if (!pg) {
+        continue;
+      }
       for (const auto& p : pg->GetProperties()) {
         property_name_to_index_.emplace(p.name, i);
         property_name_to_primary_.emplace(p.name, p.is_primary);
@@ -578,6 +590,8 @@ EdgeInfo::EdgeInfo(const std::string& src_label, const std::string& edge_label,
     : impl_(new Impl(src_label, edge_label, dst_label, chunk_size,
                      src_chunk_size, dst_chunk_size, directed, prefix,
                      adjacent_lists, property_groups, version)) {}
+
+EdgeInfo::~EdgeInfo() = default;
 
 const std::string& EdgeInfo::GetSrcLabel() const { return impl_->src_label_; }
 
@@ -1046,13 +1060,17 @@ class GraphInfo::Impl {
         version_(std::move(version)),
         extra_info_(extra_info) {
     for (size_t i = 0; i < vertex_infos_.size(); i++) {
-      vlabel_to_index_[vertex_infos_[i]->GetLabel()] = i;
+      if (vertex_infos_[i] != nullptr) {
+        vlabel_to_index_[vertex_infos_[i]->GetLabel()] = i;
+      }
     }
     for (size_t i = 0; i < edge_infos_.size(); i++) {
-      std::string edge_key = ConcatEdgeTriple(edge_infos_[i]->GetSrcLabel(),
-                                              edge_infos_[i]->GetEdgeLabel(),
-                                              edge_infos_[i]->GetDstLabel());
-      elabel_to_index_[edge_key] = i;
+      if (edge_infos_[i] != nullptr) {
+        std::string edge_key = ConcatEdgeTriple(edge_infos_[i]->GetSrcLabel(),
+                                                edge_infos_[i]->GetEdgeLabel(),
+                                                edge_infos_[i]->GetDstLabel());
+        elabel_to_index_[edge_key] = i;
+      }
     }
   }
 
@@ -1094,6 +1112,8 @@ GraphInfo::GraphInfo(
     const std::unordered_map<std::string, std::string>& extra_info)
     : impl_(new Impl(graph_name, std::move(vertex_infos), std::move(edge_infos),
                      prefix, version, extra_info)) {}
+
+GraphInfo::~GraphInfo() = default;
 
 const std::string& GraphInfo::GetName() const { return impl_->name_; }
 

--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -1198,6 +1198,9 @@ std::shared_ptr<GraphInfo> CreateGraphInfo(
     const EdgeInfoVector& edge_infos, const std::string& prefix,
     std::shared_ptr<const InfoVersion> version,
     const std::unordered_map<std::string, std::string>& extra_info) {
+  if (name.empty()) {
+    return nullptr;
+  }
   return std::make_shared<GraphInfo>(name, vertex_infos, edge_infos, prefix,
                                      version, extra_info);
 }

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -601,6 +601,12 @@ TEST_CASE("GraphInfo") {
     REQUIRE(graph_info_with_empty_prefix->IsValidated() == false);
   }
 
+  SECTION("CreateGraphInfo") {
+    auto graph_info_empty_name =
+        CreateGraphInfo("", {vertex_info}, {edge_info}, "test_graph/");
+    REQUIRE(graph_info_empty_name == nullptr);
+  }
+
   SECTION("Dump") {
     auto dump_result = graph_info->Dump();
     REQUIRE(dump_result.status().ok());

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -229,12 +229,11 @@ TEST_CASE("VertexInfo") {
     auto invalid_vertex_info0 = CreateVertexInfo(
         label, chunk_size, {invalid_pg}, "test_vertex/", version);
     REQUIRE(invalid_vertex_info0->IsValidated() == false);
-    auto invalid_vertex_info1 =
-        CreateVertexInfo("", chunk_size, {pg}, "test_vertex/", version);
-    REQUIRE(invalid_vertex_info1->IsValidated() == false);
-    auto invalid_vertex_info2 =
-        CreateVertexInfo(label, 0, {pg}, "test_vertex/", version);
-    REQUIRE(invalid_vertex_info2->IsValidated() == false);
+    VertexInfo invalid_vertex_info1("", chunk_size, {pg}, "test_vertex/",
+                                    version);
+    REQUIRE(invalid_vertex_info1.IsValidated() == false);
+    VertexInfo invalid_vertex_info2(label, 0, {pg}, "test_vertex/", version);
+    REQUIRE(invalid_vertex_info2.IsValidated() == false);
     // check if prefix empty
     auto vertex_info_empty_prefix =
         CreateVertexInfo(label, chunk_size, {pg}, "", version);
@@ -384,30 +383,23 @@ TEST_CASE("EdgeInfo") {
                        src_chunk_size, dst_chunk_size, directed, {adj_list},
                        {invalid_pg}, "test_edge/", version);
     REQUIRE(invalid_edge_info0->IsValidated() == false);
-    auto invalid_edge_info1 = CreateEdgeInfo(
-        "", edge_label, dst_label, chunk_size, src_chunk_size, dst_chunk_size,
-        directed, {adj_list}, {pg}, "test_edge/", version);
-    REQUIRE(invalid_edge_info1->IsValidated() == false);
-    auto invalid_edge_info2 = CreateEdgeInfo(
-        src_label, "", dst_label, chunk_size, src_chunk_size, dst_chunk_size,
-        directed, {adj_list}, {pg}, "test_edge/", version);
-    REQUIRE(invalid_edge_info2->IsValidated() == false);
-    auto invalid_edge_info3 = CreateEdgeInfo(
-        src_label, edge_label, "", chunk_size, src_chunk_size, dst_chunk_size,
-        directed, {adj_list}, {pg}, "test_edge/", version);
-    REQUIRE(invalid_edge_info3->IsValidated() == false);
-    auto invalid_edge_info4 = CreateEdgeInfo(
-        src_label, edge_label, dst_label, 0, src_chunk_size, dst_chunk_size,
-        directed, {adj_list}, {pg}, "test_edge/", version);
-    REQUIRE(invalid_edge_info4->IsValidated() == false);
-    auto invalid_edge_info5 = CreateEdgeInfo(
-        src_label, edge_label, dst_label, chunk_size, 0, dst_chunk_size,
-        directed, {adj_list}, {pg}, "test_edge/", version);
-    REQUIRE(invalid_edge_info5->IsValidated() == false);
-    auto invalid_edge_info6 = CreateEdgeInfo(
-        src_label, edge_label, dst_label, chunk_size, src_chunk_size, 0,
-        directed, {adj_list}, {pg}, "test_edge/", version);
-    REQUIRE(invalid_edge_info6->IsValidated() == false);
+    for (int i = 0; i < 3; i++) {
+      std::vector<std::string> labels = {src_label, edge_label, dst_label};
+      labels[i] = "";
+      EdgeInfo invalid_edge_info1(labels[0], labels[1], labels[2], chunk_size,
+                                  src_chunk_size, dst_chunk_size, directed,
+                                  {adj_list}, {pg}, "test_edge/", version);
+      REQUIRE(invalid_edge_info1.IsValidated() == false);
+    }
+    for (int i = 0; i < 3; i++) {
+      std::vector<int> sizes = {chunk_size, src_chunk_size, dst_chunk_size};
+      sizes[i] = 0;
+      EdgeInfo invalid_edge_info2(src_label, edge_label, dst_label, sizes[0],
+                                  sizes[1], sizes[2], directed, {adj_list},
+                                  {pg}, "test_edge/", version);
+      REQUIRE(invalid_edge_info2.IsValidated() == false);
+    }
+
     // check if prefix empty
     auto edge_info_with_empty_prefix = CreateEdgeInfo(
         src_label, edge_label, dst_label, chunk_size, src_chunk_size,
@@ -417,7 +409,7 @@ TEST_CASE("EdgeInfo") {
 
   SECTION("CreateEdgeInfo") {
     for (int i = 0; i < 3; i++) {
-      std::vector<std::string> labels = {"person", "knows", "person"};
+      std::vector<std::string> labels = {src_label, edge_label, dst_label};
       labels[i] = "";
       auto edge_info = CreateEdgeInfo(
           labels[0], labels[1], labels[2], chunk_size, src_chunk_size,
@@ -425,7 +417,7 @@ TEST_CASE("EdgeInfo") {
       REQUIRE(edge_info == nullptr);
     }
     for (int i = 0; i < 3; i++) {
-      std::vector<int> sizes = {1024, 100, 100};
+      std::vector<int> sizes = {chunk_size, src_chunk_size, dst_chunk_size};
       sizes[i] = 0;
       auto edge_info = CreateEdgeInfo(src_label, edge_label, dst_label,
                                       sizes[0], sizes[1], sizes[2], directed,
@@ -469,9 +461,9 @@ src_label: person
 version: gar/v1
 )";
     REQUIRE(dump_result.value() == expected);
-    auto edge_info_empty_version =
-        CreateEdgeInfo(src_label, edge_label, dst_label, chunk_size,
-                       src_chunk_size, dst_chunk_size, directed, {}, {});
+    auto edge_info_empty_version = CreateEdgeInfo(
+        src_label, edge_label, dst_label, chunk_size, src_chunk_size,
+        dst_chunk_size, directed, {adj_list}, {pg});
     REQUIRE(edge_info_empty_version->Dump().status().ok());
   }
 
@@ -589,12 +581,12 @@ TEST_CASE("GraphInfo") {
     auto invalid_graph_info1 = CreateGraphInfo(
         name, {vertex_info}, {invalid_edge_info}, "test_graph/", version);
     REQUIRE(invalid_graph_info1->IsValidated() == false);
-    auto invalid_graph_info2 =
-        CreateGraphInfo("", {vertex_info}, {edge_info}, "test_graph/", version);
-    REQUIRE(invalid_graph_info2->IsValidated() == false);
-    auto invalid_graph_info3 =
-        CreateGraphInfo(name, {vertex_info}, {edge_info}, "", version);
-    REQUIRE(invalid_graph_info3->IsValidated() == false);
+    GraphInfo invalid_graph_info2("", {vertex_info}, {edge_info}, "test_graph/",
+                                  version);
+    REQUIRE(invalid_graph_info2.IsValidated() == false);
+    GraphInfo invalid_graph_info3(name, {vertex_info}, {edge_info}, "",
+                                  version);
+    REQUIRE(invalid_graph_info3.IsValidated() == false);
     // check if prefix empty, graph_info with empty prefix is invalid
     auto graph_info_with_empty_prefix =
         CreateGraphInfo(name, {vertex_info}, {edge_info}, "", version);

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -242,7 +242,7 @@ TEST_CASE("VertexInfo") {
   }
 
   SECTION("CreateVertexInfo") {
-    auto vertex_info3 = CreateVertexInfo("", chunk_size, "test_vertex/");
+    auto vertex_info3 = CreateVertexInfo("", chunk_size, {pg}, "test_vertex/");
     REQUIRE(vertex_info3 == nullptr);
 
     auto vertex_info4 = CreateVertexInfo(label, 0, {pg}, "test_vertex/");


### PR DESCRIPTION

## Proposed changes
This change aims to fix that PropertyGroup with empty properties bug
- Not allow create property group with empty properties, if so, it's invalid;
- Not allow create edge info with empty adj list vector, if so, it's invalid;
- Not allow empty label name and chunk_size <= when create VertexInfo/EdgeInfo
- Add `try..  catch..` to catch exception in `Dump` methods. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
close #392

