### PR TITLE
[BugFix][C++]: Fix `VertexInfo/EdgeInfo` can not be saved to a URI path

### DIFF
--- a/cpp/src/graph_info.cc
+++ b/cpp/src/graph_info.cc
@@ -478,7 +478,7 @@ Status VertexInfo::Save(const std::string& path) const {
   std::string no_url_path;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(path, &no_url_path));
   GAR_ASSIGN_OR_RAISE(auto yaml_content, this->Dump());
-  return fs->WriteValueToFile(yaml_content, path);
+  return fs->WriteValueToFile(yaml_content, no_url_path);
 }
 
 class EdgeInfo::Impl {
@@ -964,7 +964,7 @@ Status EdgeInfo::Save(const std::string& path) const {
   std::string no_url_path;
   GAR_ASSIGN_OR_RAISE(auto fs, FileSystemFromUriOrPath(path, &no_url_path));
   GAR_ASSIGN_OR_RAISE(auto yaml_content, this->Dump());
-  return fs->WriteValueToFile(yaml_content, path);
+  return fs->WriteValueToFile(yaml_content, no_url_path);
 }
 
 namespace {

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -274,6 +274,13 @@ version: gar/v1
     REQUIRE(vertex_info_empty_version->Dump().status().ok());
   }
 
+  SECTION("Save") {
+    // save to a simple output path
+    REQUIRE(vertex_info->Save("/tmp/" + label + ".vertex.yml").ok());
+    // save to a URI path
+    REQUIRE(vertex_info->Save("file:///tmp/" + label + ".vertex.yml").ok());
+  }
+
   SECTION("AddPropertyGroup") {
     auto pg2 = CreatePropertyGroup({Property("p2", int32(), false)},
                                    FileType::CSV, "p2/");
@@ -467,6 +474,13 @@ version: gar/v1
     REQUIRE(edge_info_empty_version->Dump().status().ok());
   }
 
+  SECTION("Save") {
+    // save to a simple output path
+    REQUIRE(edge_info->Save("/tmp/" + edge_label + ".edge.yml").ok());
+    // save to a URI path
+    REQUIRE(edge_info->Save("file:///tmp/" + edge_label + ".edge.yml").ok());
+  }
+
   SECTION("AddAdjacentList") {
     auto adj_list2 = CreateAdjacentList(AdjListType::ordered_by_dest,
                                         FileType::CSV, "ordered_by_dest/");
@@ -617,6 +631,13 @@ vertices:
     auto graph_info_empty_version =
         CreateGraphInfo(name, {vertex_info}, {edge_info}, "test_graph/");
     REQUIRE(graph_info_empty_version->Dump().status().ok());
+  }
+
+  SECTION("Save") {
+    // save to a simple output path
+    REQUIRE(graph_info->Save("/tmp/" + name + ".graph.yml").ok());
+    // save to a URI path
+    REQUIRE(graph_info->Save("file:///tmp/" + name + ".graph.yml").ok());
   }
 
   SECTION("AddVertex") {


### PR DESCRIPTION
## Proposed changes
Fix `VertexInfo/EdgeInfo` can not save to a URI path.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
close #394 
