### PR TITLE
[Spark][Java][Info] Add property-group-related methods for edge info and vertex info

### DIFF
--- a/spark/graphar/src/main/java/com/alibaba/graphar/info/EdgeInfo.java
+++ b/spark/graphar/src/main/java/com/alibaba/graphar/info/EdgeInfo.java
@@ -235,7 +235,7 @@ public class EdgeInfo {
     //    }
 
     DataType getPropertyType(String propertyName) {
-        return propertyGroups.getProperty(propertyName).getDataType();
+        return propertyGroups.getPropertyType(propertyName);
     }
 
     boolean isPrimaryKey(String propertyName) {
@@ -267,8 +267,16 @@ public class EdgeInfo {
     //
     //    }
 
-    public EdgeTriple getEdgeTriple() {
-        return edgeTriple;
+    public String getSrcLabel() {
+        return edgeTriple.getSrcLabel();
+    }
+
+    public String getEdgeLabel() {
+        return edgeTriple.getEdgeLabel();
+    }
+
+    public String getDstLabel() {
+        return edgeTriple.getDstLabel();
     }
 
     public long getChunkSize() {
@@ -281,6 +289,10 @@ public class EdgeInfo {
 
     public long getDstChunkSize() {
         return dstChunkSize;
+    }
+
+    public boolean isDirected() {
+        return directed;
     }
 
     public String getPrefix() {

--- a/spark/graphar/src/main/java/com/alibaba/graphar/info/PropertyGroup.java
+++ b/spark/graphar/src/main/java/com/alibaba/graphar/info/PropertyGroup.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.graphar.info;
 
+import com.alibaba.graphar.info.type.DataType;
 import com.alibaba.graphar.info.type.FileType;
 import com.alibaba.graphar.info.yaml.PropertyGroupYamlParser;
 import java.util.ArrayList;
@@ -107,16 +108,20 @@ class PropertyGroups {
         return new PropertyGroups(newPropertyGroups, newPropertyGroupsAsMap, newProperties);
     }
 
-    public boolean hasProperty(String propertyName) {
+    boolean hasProperty(String propertyName) {
         return properties.containsKey(propertyName);
     }
 
-    public boolean hasPropertyGroup(PropertyGroup propertyGroup) {
+    boolean hasPropertyGroup(PropertyGroup propertyGroup) {
         return propertyGroupsAsList.contains(propertyGroup);
     }
 
-    public int getPropertyGroupNum() {
+    int getPropertyGroupNum() {
         return propertyGroupsAsMap.values().size();
+    }
+
+    DataType getPropertyType(String propertyName) {
+        return properties.get(propertyName).getDataType();
     }
 
     boolean isPrimaryKey(String propertyName) {

--- a/spark/graphar/src/main/java/com/alibaba/graphar/info/PropertyGroup.java
+++ b/spark/graphar/src/main/java/com/alibaba/graphar/info/PropertyGroup.java
@@ -18,28 +18,48 @@ package com.alibaba.graphar.info;
 
 import com.alibaba.graphar.info.type.FileType;
 import com.alibaba.graphar.info.yaml.PropertyGroupYamlParser;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
-public class PropertyGroup {
-    private final List<Property> properties;
+public class PropertyGroup implements Iterable<Property> {
+    private final Map<String, Property> properties;
     private final FileType fileType;
     private final String prefix;
 
-    public PropertyGroup(List<Property> properties, FileType fileType, String prefix) {
+    public PropertyGroup(Map<String, Property> properties, FileType fileType, String prefix) {
         this.properties = properties;
         this.fileType = fileType;
         this.prefix = prefix;
     }
 
-    PropertyGroup(PropertyGroupYamlParser yamlParser) {
-        this.properties =
-                yamlParser.getProperties().stream().map(Property::new).collect(Collectors.toList());
-        this.fileType = yamlParser.getFile_type();
-        this.prefix = yamlParser.getPrefix();
+    public PropertyGroup(List<Property> properties, FileType fileType, String prefix) {
+        this(
+                properties.stream()
+                        .collect(Collectors.toMap(Property::getName, Function.identity())),
+                fileType,
+                prefix);
     }
 
-    public List<Property> getProperties() {
+    PropertyGroup(PropertyGroupYamlParser yamlParser) {
+        this(
+                yamlParser.getProperties().stream().map(Property::new).collect(Collectors.toList()),
+                yamlParser.getFile_type(),
+                yamlParser.getPrefix());
+    }
+
+    @NotNull
+    @Override
+    public Iterator<Property> iterator() {
+        return properties.values().iterator();
+    }
+
+    public Map<String, Property> getProperties() {
         return properties;
     }
 
@@ -49,5 +69,77 @@ public class PropertyGroup {
 
     public String getPrefix() {
         return prefix;
+    }
+}
+
+class PropertyGroups {
+    private final List<PropertyGroup> propertyGroupsAsList;
+    private final Map<String, PropertyGroup> propertyGroupsAsMap;
+    private final Map<String, Property> properties;
+
+    PropertyGroups(List<PropertyGroup> propertyGroupsAsList) {
+        this.propertyGroupsAsList = propertyGroupsAsList;
+        this.propertyGroupsAsMap =
+                propertyGroupsAsList.stream()
+                        .collect(Collectors.toMap(PropertyGroup::getPrefix, Function.identity()));
+        this.properties =
+                propertyGroupsAsList.stream()
+                        .flatMap(propertyGroup -> propertyGroup.getProperties().values().stream())
+                        .collect(Collectors.toMap(Property::getName, Function.identity()));
+    }
+
+    private PropertyGroups(
+            List<PropertyGroup> propertyGroupsAsList,
+            Map<String, PropertyGroup> propertyGroupsAsMap,
+            Map<String, Property> properties) {
+        this.propertyGroupsAsList = propertyGroupsAsList;
+        this.propertyGroupsAsMap = propertyGroupsAsMap;
+        this.properties = properties;
+    }
+
+    PropertyGroups addPropertyGroup(PropertyGroup propertyGroup) {
+        List<PropertyGroup> newPropertyGroups = new ArrayList<>(propertyGroupsAsList);
+        newPropertyGroups.add(propertyGroup);
+        Map<String, PropertyGroup> newPropertyGroupsAsMap = new HashMap<>(propertyGroupsAsMap);
+        newPropertyGroupsAsMap.put(propertyGroup.getPrefix(), propertyGroup);
+        Map<String, Property> newProperties = new HashMap<>(properties);
+        newProperties.putAll(propertyGroup.getProperties());
+        return new PropertyGroups(newPropertyGroups, newPropertyGroupsAsMap, newProperties);
+    }
+
+    public boolean hasProperty(String propertyName) {
+        return properties.containsKey(propertyName);
+    }
+
+    public boolean hasPropertyGroup(PropertyGroup propertyGroup) {
+        return propertyGroupsAsList.contains(propertyGroup);
+    }
+
+    public int getPropertyGroupNum() {
+        return propertyGroupsAsMap.values().size();
+    }
+
+    boolean isPrimaryKey(String propertyName) {
+        return properties.get(propertyName).isPrimary();
+    }
+
+    boolean isNullableKey(String propertyName) {
+        return properties.get(propertyName).isNullable();
+    }
+
+    List<PropertyGroup> toList() {
+        return propertyGroupsAsList;
+    }
+
+    PropertyGroup getPropertyGroup(String propertyName) {
+        return propertyGroupsAsMap.get(propertyName);
+    }
+
+    Map<String, Property> getProperties() {
+        return properties;
+    }
+
+    Property getProperty(String propertyName) {
+        return properties.get(propertyName);
     }
 }

--- a/spark/graphar/src/main/java/com/alibaba/graphar/info/VertexInfo.java
+++ b/spark/graphar/src/main/java/com/alibaba/graphar/info/VertexInfo.java
@@ -91,7 +91,7 @@ public class VertexInfo {
                 label, chunkSize, propertyGroups.addPropertyGroup(propertyGroup), prefix, version);
     }
 
-    int PropertyGroupNum() {
+    int propertyGroupNum() {
         return propertyGroups.getPropertyGroupNum();
     }
 
@@ -100,7 +100,7 @@ public class VertexInfo {
     }
 
     DataType getPropertyType(String propertyName) {
-        return propertyGroups.getProperty(propertyName).getDataType();
+        return propertyGroups.getPropertyType(propertyName);
     }
 
     boolean hasProperty(String propertyName) {
@@ -120,6 +120,7 @@ public class VertexInfo {
     }
 
     // TODO(@Thespica): Implement file path get methods
+    //
     //    String getFilePath(PropertyGroup propertyGroup,
     //                                    long chunkIndex) {
     //
@@ -135,6 +136,7 @@ public class VertexInfo {
     //    }
 
     // TODO(@Thespica): Implement save and dump methods
+    //
     //    void save(String fileName) {
     //
     //    }

--- a/spark/graphar/src/main/java/com/alibaba/graphar/info/yaml/EdgeYamlParser.java
+++ b/spark/graphar/src/main/java/com/alibaba/graphar/info/yaml/EdgeYamlParser.java
@@ -26,6 +26,7 @@ public class EdgeYamlParser {
     private long chunk_size;
     private long src_chunk_size;
     private long dst_chunk_size;
+    private boolean directed;
     private String prefix;
     private List<AdjacentListYamlParser> adjacent_lists;
     private List<PropertyGroupYamlParser> property_groups;
@@ -38,6 +39,7 @@ public class EdgeYamlParser {
         this.chunk_size = 0;
         this.src_chunk_size = 0;
         this.dst_chunk_size = 0;
+        this.directed = false;
         this.prefix = "";
         this.adjacent_lists = new ArrayList<>();
         this.property_groups = new ArrayList<>();
@@ -66,6 +68,14 @@ public class EdgeYamlParser {
 
     public void setDst_label(String dst_label) {
         this.dst_label = dst_label;
+    }
+
+    public boolean isDirected() {
+        return directed;
+    }
+
+    public void setDirected(boolean directed) {
+        this.directed = directed;
     }
 
     public long getChunk_size() {


### PR DESCRIPTION
## Proposed changes

Here I created a class called `PropertyGroups` for conveiently used by vertex info and edge info, it shouldn't be exposed to out side.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/alibaba/GraphAr/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

related issue #406 
